### PR TITLE
Speed up CI with toolchain-aware caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,15 @@ jobs:
           SERVER_ADDRESS=127.0.0.1
           EOF
 
-      # Cache Hex/Mix package archives so mix deps.get avoids re-downloading
-      # from hex.pm even when the deps/_build cache key misses
-      - name: Cache Hex and Mix
+      # Cache Hex's package tarballs and registry (~/.hex) so mix deps.get
+      # avoids re-downloading from hex.pm when the deps/_build key misses.
+      # setup-beam force-reinstalls the hex tool into ~/.mix every run, so
+      # that directory is not worth caching.
+      - name: Cache Hex
         uses: actions/cache@v5
         with:
           path: |
             ~/.hex
-            ~/.mix
           key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-hex
           restore-keys: |
             ${{ runner.os }}-hex-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Setup Elixir
       - name: Set up Elixir
@@ -69,7 +69,7 @@ jobs:
       # Cache Hex/Mix package archives so mix deps.get avoids re-downloading
       # from hex.pm even when the deps/_build cache key misses
       - name: Cache Hex and Mix
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.hex
@@ -82,7 +82,7 @@ jobs:
       # versions so _build artifacts are never reused across toolchain bumps;
       # restore-keys lets an older mix.lock build be reused incrementally.
       - name: Cache deps and _build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -103,9 +103,12 @@ jobs:
         env:
           MIX_ENV: test
 
-      # Run Credo for code analysis
+      # Run Credo for code analysis. Runs under the test env (like the compile
+      # step) so it reuses the same _build instead of triggering a dev compile.
       - name: Run Credo
         run: mix credo
+        env:
+          MIX_ENV: test
 
       # Run tests when available
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
 
       # Setup Elixir
       - name: Set up Elixir
+        id: beam
         uses: erlef/setup-beam@v1
         with:
           elixir-version: "1.20.x"
@@ -65,24 +66,42 @@ jobs:
           SERVER_ADDRESS=127.0.0.1
           EOF
 
-      # Cache dependencies and build artifacts
+      # Cache Hex/Mix package archives so mix deps.get avoids re-downloading
+      # from hex.pm even when the deps/_build cache key misses
+      - name: Cache Hex and Mix
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.hex
+            ~/.mix
+          key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-hex
+          restore-keys: |
+            ${{ runner.os }}-hex-
+
+      # Cache dependencies and build artifacts. The key pins the OTP/Elixir
+      # versions so _build artifacts are never reused across toolchain bumps;
+      # restore-keys lets an older mix.lock build be reused incrementally.
       - name: Cache deps and _build
         uses: actions/cache@v4
         with:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-mix-
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
 
       # Install dependencies
       - name: Install dependencies
         run: mix deps.get
 
-      # Compile project (with warnings as errors)
+      # Compile project in the test environment (with warnings as errors) so
+      # the cached _build only holds test artifacts and mix test reuses them
       - name: Compile
         run: mix compile --warnings-as-errors
+        env:
+          MIX_ENV: test
 
       # Run Credo for code analysis
       - name: Run Credo

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,14 +28,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libluajit-5.1-dev
 
-      # Cache Hex/Mix package archives so mix deps.get avoids re-downloading
-      # from hex.pm even when the deps/_build cache key misses
-      - name: Cache Hex and Mix
+      # Cache Hex's package tarballs and registry (~/.hex) so mix deps.get
+      # avoids re-downloading from hex.pm when the deps/_build key misses.
+      # setup-beam force-reinstalls the hex tool into ~/.mix every run, so
+      # that directory is not worth caching.
+      - name: Cache Hex
         uses: actions/cache@v5
         with:
           path: |
             ~/.hex
-            ~/.mix
           key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-hex
           restore-keys: |
             ${{ runner.os }}-hex-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Elixir
         id: beam
@@ -31,7 +31,7 @@ jobs:
       # Cache Hex/Mix package archives so mix deps.get avoids re-downloading
       # from hex.pm even when the deps/_build cache key misses
       - name: Cache Hex and Mix
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.hex
@@ -44,7 +44,7 @@ jobs:
       # job (docs builds in dev env) so the two jobs don't overwrite each
       # other's _build cache entries.
       - name: Cache deps and _build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Elixir
+        id: beam
         uses: erlef/setup-beam@v1
         with:
           elixir-version: "1.20.x"
@@ -26,6 +27,31 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libluajit-5.1-dev
+
+      # Cache Hex/Mix package archives so mix deps.get avoids re-downloading
+      # from hex.pm even when the deps/_build cache key misses
+      - name: Cache Hex and Mix
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.hex
+            ~/.mix
+          key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-hex
+          restore-keys: |
+            ${{ runner.os }}-hex-
+
+      # Cache dependencies and build artifacts. Keyed separately from the CI
+      # job (docs builds in dev env) so the two jobs don't overwrite each
+      # other's _build cache entries.
+      - name: Cache deps and _build
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-mix-docs-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-mix-docs-
 
       - name: Install dependencies
         run: mix deps.get


### PR DESCRIPTION
Cache Hex/Mix archives and pin cache keys to the resolved OTP/Elixir versions, compile in the test env so _build holds only test artifacts, and add caching to the docs workflow.