### PR TITLE
Add passive buffs stats to player

### DIFF
--- a/lib/ms2ex/context/item_enchant_stats.ex
+++ b/lib/ms2ex/context/item_enchant_stats.ex
@@ -13,7 +13,7 @@ defmodule Ms2ex.Context.ItemEnchantStats do
         acc
       else
         attr = Enums.BasicStatType.get_key(attr_nr)
-        stat = Types.ItemStat.build(attr, :flat, value, :basic)
+        stat = Types.ItemStat.build(attr, :rate, value, :basic)
         Map.put(acc, attr, stat)
       end
     end)

--- a/lib/ms2ex/context/item_static_stats.ex
+++ b/lib/ms2ex/context/item_static_stats.ex
@@ -9,10 +9,14 @@ defmodule Ms2ex.Context.ItemStaticStats do
     static_id = get_in(item.metadata, [:option, :static_id])
 
     if static_id do
-      static_id
-      |> Storage.Tables.ItemOptions.find_static(item.rarity)
-      |> get_static_stats()
-      |> get_pick_stats(item, pick_options)
+      static_stats =
+        static_id
+        |> Storage.Tables.ItemOptions.find_static(item.rarity)
+        |> get_static_stats()
+
+      if lua_static?(item),
+        do: get_pick_stats(static_stats, item, pick_options),
+        else: static_stats
     else
       %{}
     end
@@ -67,6 +71,9 @@ defmodule Ms2ex.Context.ItemStaticStats do
     end)
   end
 
+  defp lua_static?(%Schema.Item{metadata: %{option: %{static_type: 2}}}), do: true
+  defp lua_static?(_item), do: false
+
   defp process_pick_stat(item, static_stats, type, {pick_stat, pick_value}) do
     # Initialize empty stat if not already present from static options
     static_stats =
@@ -84,6 +91,9 @@ defmodule Ms2ex.Context.ItemStaticStats do
 
     # Put / update static stat
     value = if type == :flat, do: trunc(value), else: value
-    Map.put(static_stats, pick_stat, %{static_stat | value: value})
+
+    if value > 0,
+      do: Map.put(static_stats, pick_stat, %{static_stat | value: value}),
+      else: static_stats
   end
 end

--- a/lib/ms2ex/context/item_stats.ex
+++ b/lib/ms2ex/context/item_stats.ex
@@ -1,10 +1,10 @@
 defmodule Ms2ex.Context.ItemStats do
   @moduledoc """
-  Aggregates the stat bonuses granted by equipped items and applies them to a
-  character's stats.
+  Aggregates the stat bonuses granted by equipped items and learned passive
+  skills, then applies them to a character's stats.
 
-  Each item's calculated stats are summed over every equipped item and added
-  to the character's base stat values.
+  Calculated item and passive effects are summed and added to the character's
+  base stat values.
   """
 
   alias Ms2ex.Context
@@ -13,12 +13,14 @@ defmodule Ms2ex.Context.ItemStats do
   alias Ms2ex.Formulas.GearScore
   alias Ms2ex.Repo
   alias Ms2ex.Schema
+  alias Ms2ex.Storage
 
   @item_stat_groups [:constants, :statics, :randoms, :enchants, :limit_break_enchants]
+  @empty_stat_groups %{values: %{}, rates: %{}, special_values: %{}, special_rates: %{}}
 
   @doc """
-  Rebuilds a character's stats from the persisted base plus the bonuses of
-  every equipped item. The base is reloaded so repeated applications never
+  Rebuilds a character's stats from the persisted base plus equipped-item and
+  learned-passive bonuses. The base is reloaded so repeated applications never
   stack.
   """
   def apply(%Schema.Character{} = character) do
@@ -27,31 +29,28 @@ defmodule Ms2ex.Context.ItemStats do
   end
 
   @doc """
-  Rebuilds a character's stats and returns the equipment-derived packet data.
+  Rebuilds a character's stats and returns the derived packet data.
   """
   def apply_with_equipment_stats(%Schema.Character{} = character) do
-    character = Repo.preload(character, :stats, force: true)
+    character = Repo.preload(character, [:stats, skill_tabs: :skills], force: true)
     equips = equipped_gear(character)
 
-    {bonuses, rates, special_values, special_rates} =
-      Enum.reduce(equips, {%{}, %{}, %{}, %{}}, fn item, stats ->
-        {bonuses, rates, special_values, special_rates} = stats
-
-        {
-          merge_values(bonuses, item_stat_values(item, :basic)),
-          merge_values(rates, item_stat_rates(item, :basic)),
-          merge_values(special_values, item_stat_values(item, :special)),
-          merge_values(special_rates, item_stat_rates(item, :special))
-        }
+    stat_groups =
+      Enum.reduce(equips, @empty_stat_groups, fn item, stat_groups ->
+        stat_groups
+        |> merge_stat_groups(item_stat_groups(item))
+        |> merge_stat_groups(item_effect_stats(item))
       end)
 
+    stat_groups = merge_stat_groups(stat_groups, passive_effect_stats(character))
+
     character = reset_base_stats(character)
-    character = apply_stats(character, bonuses, rates)
+    character = apply_stats(character, stat_groups.values, stat_groups.rates)
 
     equipment_stats = %{
-      basic_rates: rates,
-      special_values: special_values,
-      special_rates: special_rates
+      basic_rates: stat_groups.rates,
+      special_values: stat_groups.special_values,
+      special_rates: stat_groups.special_rates
     }
 
     {%{character | gear_score: calculate_gear_score(equips)}, equipment_stats}
@@ -135,6 +134,82 @@ defmodule Ms2ex.Context.ItemStats do
       item.stats
       |> Map.get(group, %{})
       |> Map.values()
+    end)
+  end
+
+  defp item_stat_groups(item) do
+    %{
+      values: item_stat_values(item, :basic),
+      rates: item_stat_rates(item, :basic),
+      special_values: item_stat_values(item, :special),
+      special_rates: item_stat_rates(item, :special)
+    }
+  end
+
+  defp item_effect_stats(item) do
+    effects = Map.get(item.metadata, :additional_effects, [])
+
+    effect_stats(effects)
+  end
+
+  defp passive_effect_stats(%Schema.Character{} = character) do
+    character
+    |> Context.Skills.get_active_tab()
+    |> case do
+      %Schema.SkillTab{skills: skills} ->
+        Enum.reduce(skills, @empty_stat_groups, &merge_passive_skill/2)
+
+      _ ->
+        @empty_stat_groups
+    end
+  end
+
+  defp merge_passive_skill(skill, stats) do
+    [skill | Map.get(skill, :sub_skills, []) || []]
+    |> Enum.filter(&learned_passive?/1)
+    |> Enum.reduce(stats, fn passive_skill, stats ->
+      merge_stat_groups(stats, skill_effect_stats(passive_skill))
+    end)
+  end
+
+  defp learned_passive?(%{skill_id: id, level: level}) when level > 0 do
+    match?(%{property: %{type: 1}}, Storage.Skills.get_meta(id))
+  end
+
+  defp learned_passive?(_skill), do: false
+
+  defp skill_effect_stats(%{skill_id: id, level: level}) do
+    case Storage.Skills.get_meta(id) do
+      %{levels: levels} ->
+        effects = get_in(levels, [Integer.to_string(level), :skills]) || []
+
+        effect_stats(Enum.flat_map(effects, &Map.get(&1, :skills, [])))
+
+      _ ->
+        @empty_stat_groups
+    end
+  end
+
+  defp effect_stats(effects) do
+    Enum.reduce(effects, @empty_stat_groups, fn %{id: id, level: level}, stats ->
+      case Storage.Skills.get_effect(id, level) do
+        %{status: status} ->
+          merge_stat_groups(stats, %{
+            values: Map.get(status, :values, %{}),
+            rates: Map.get(status, :rates, %{}),
+            special_values: Map.get(status, :special_values, %{}),
+            special_rates: Map.get(status, :special_rates, %{})
+          })
+
+        _ ->
+          stats
+      end
+    end)
+  end
+
+  defp merge_stat_groups(left, right) do
+    Map.merge(left, right, fn _group, left_values, right_values ->
+      merge_values(left_values, right_values)
     end)
   end
 


### PR DESCRIPTION
Changes:

- Replaced the opaque four-tuple accumulator with named stat groups.
- Unified item-effect and passive-effect merging.
- Simplified learned passive-skill traversal.
- Updated documentation.
- No hard-coded SP or attack-speed values.

- Applies Lua pick calculations only to Lua static options.
- Prevents zero or negative picks from overwriting valid stats.

- Correctly treats enchantment factors as rate stats.