### PR TITLE
State-skill resource costs & passive regen fixes

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,15 +69,6 @@ Applied today: `status.values` / `status.rates` stat modifiers, the
 - recovery is skipped on mob-owned buffs; empty effects are applied as no-op
   buffs
 
-### 5. Skill resource costs — [Partial]
-
-Regular skill casts validate and consume SP/stamina (the cast is gated on
-having enough, then both are drained). What remains:
-
-- state skills (recv `0x21`) validate and consume nothing
-- state skills have no per-tick re-validation/consumption loop and are never
-  cancelled when the actor state changes
-
 ### 6. SkillDamage Tile damage mode — [Partial]
 
 The DotDamage (0x3) record is implemented and driven by the buff tick loop.
@@ -125,6 +116,15 @@ damage accumulation + `DpsStat` flow (see `docs/internal/party-dps-meter.md`).
 
 ## Recently completed
 
+- Passive HP/SP/stamina regen fix: inverted dead-actor guard on
+  `Character.Stats.regen/2` (from #88) meant living characters never
+  regenerated; exposed by the Swift Swim stamina drain. Consumption now
+  also suspends that stat's regen for the projected Recovery*WaitTick
+  (new server.constants.xml ingest doc), so drains deplete instead of
+  racing regen
+- State-skill resource costs: cast validation + consumption, per-tick drain
+  loop at the projected motion `sequence_speed`, cancellation on state
+  mismatch / death / resource exhaustion
 - Tombstone hit/revive flow: peer HP in `FieldAddUser`, plus death-flow
   parity (gauge packet, revive order, penalty-window death count)
   ([#97](https://github.com/sgessa/ms2ex/pull/97))

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -121,10 +121,11 @@ damage accumulation + `DpsStat` flow (see `docs/internal/party-dps-meter.md`).
   regenerated; exposed by the Swift Swim stamina drain. Consumption now
   also suspends that stat's regen for the projected Recovery*WaitTick
   (new server.constants.xml ingest doc), so drains deplete instead of
-  racing regen
+  racing regen ([#98](https://github.com/sgessa/ms2ex/pull/98))
 - State-skill resource costs: cast validation + consumption, per-tick drain
   loop at the projected motion `sequence_speed`, cancellation on state
   mismatch / death / resource exhaustion
+  ([#98](https://github.com/sgessa/ms2ex/pull/98))
 - Tombstone hit/revive flow: peer HP in `FieldAddUser`, plus death-flow
   parity (gauge packet, revive order, penalty-window death count)
   ([#97](https://github.com/sgessa/ms2ex/pull/97))

--- a/lib/ms2ex/handlers/game/state_skill.ex
+++ b/lib/ms2ex/handlers/game/state_skill.ex
@@ -7,40 +7,52 @@ defmodule Ms2ex.GameHandlers.StateSkill do
 
   import Packets.PacketReader
 
+  @start 0x0
+
   def handle(packet, session) do
     {function, packet} = get_byte(packet)
 
-    if function != 0x0 do
-      :ok
+    {:ok, character} = Managers.Character.call(session.character_id, :lookup)
+
+    if function == @start do
+      start_state_skill(packet, character)
     else
-      {cast_uid, packet} = get_long(packet)
-      {server_tick, packet} = get_int(packet)
-      {skill_id, packet} = get_int(packet)
-      {skill_level, packet} = get_short(packet)
-      {state, packet} = get_int(packet)
-      {client_tick, packet} = get_int(packet)
-      {item_uid, _packet} = get_long(packet)
+      # a non-start function ends the actor's state-skill stance
+      Managers.Character.call(character, {:cancel_state_skill, :client_request})
+    end
 
-      {:ok, character} = Managers.Character.call(session.character_id, :lookup)
+    session
+  end
 
-      with true <- Storage.Skills.get_meta(skill_id) != nil,
-           true <- owned_item?(character, item_uid) do
-        skill_cast =
-          Types.SkillCast.build(character, %{
-            id: cast_uid,
-            skill_id: skill_id,
-            skill_level: skill_level,
-            server_tick: server_tick,
-            client_tick: client_tick
-          })
+  defp start_state_skill(packet, character) do
+    {cast_uid, packet} = get_long(packet)
+    {server_tick, packet} = get_int(packet)
+    {skill_id, packet} = get_int(packet)
+    {skill_level, packet} = get_short(packet)
+    {state, packet} = get_int(packet)
+    {client_tick, packet} = get_int(packet)
+    {item_uid, _packet} = get_long(packet)
 
-        Managers.SkillCast.start_link(skill_cast)
+    with true <- Storage.Skills.get_meta(skill_id) != nil,
+         true <- owned_item?(character, item_uid),
+         skill_cast <-
+           Types.SkillCast.build(character, %{
+             id: cast_uid,
+             skill_id: skill_id,
+             skill_level: skill_level,
+             server_tick: server_tick,
+             client_tick: client_tick
+           }),
+         {:ok, character} <-
+           Managers.Character.call(character, {:cast_state_skill, skill_cast, state}) do
+      Context.Field.broadcast(
+        character,
+        Packets.StateSkill.bytes(character, skill_id, cast_uid, state)
+      )
 
-        Context.Field.broadcast(
-          character,
-          Packets.StateSkill.bytes(character, skill_id, cast_uid, state)
-        )
-      end
+      # state-skill costs are drained silently by the manager; a full stat
+      # refresh here shows the initial consumption on every client
+      Context.Field.broadcast_stats(character)
     end
   end
 

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -40,6 +40,8 @@ defmodule Ms2ex.Managers.Character do
      |> Map.put(:regen_sp?, false)
      |> Map.put(:regen_sta?, false)
      |> Map.put(:skill_cooldowns, %{})
+     |> Map.put(:state_skill, nil)
+     |> Map.put(:regen_waits, %{})
      |> Map.update(
        :stat_point_sources,
        AttributePointSource.default_sources(),
@@ -62,6 +64,8 @@ defmodule Ms2ex.Managers.Character do
       |> Map.put(:death_count, Map.get(state, :death_count, 0))
       |> Map.put(:death_tick, Map.get(state, :death_tick, 0))
       |> Map.put(:instant_revive_count, Map.get(state, :instant_revive_count, 0))
+      |> Map.put(:state_skill, Map.get(state, :state_skill))
+      |> Map.put(:regen_waits, Map.get(state, :regen_waits, %{}))
 
     {:reply, :ok, updated}
   end
@@ -109,6 +113,28 @@ defmodule Ms2ex.Managers.Character do
     {:reply, {:ok, Character.Skill.cast_skill(character, skill_cast)}, character}
   end
 
+  def handle_call({:cast_state_skill, skill_cast, state}, _from, character) do
+    case character.state_skill do
+      %{skill_cast: %{id: active_id}, state: ^state} when active_id == skill_cast.id ->
+        # the same stance is already running: refresh without re-consuming
+        {:reply, {:ok, character}, character}
+
+      _ ->
+        case Character.Skill.cast_state_skill(character, skill_cast, state) do
+          {:ok, character} ->
+            character = Character.Skill.activate_state_skill(character, skill_cast, state)
+            {:reply, {:ok, character}, character}
+
+          :error ->
+            {:reply, :error, character}
+        end
+    end
+  end
+
+  def handle_call({:cancel_state_skill, _reason}, _from, character) do
+    {:reply, :ok, Character.Skill.cancel_state_skill(character)}
+  end
+
   def handle_call({:save_skill_cooldown, cooldown}, _from, character) do
     {:reply, :ok, Character.SkillCooldown.save(character, cooldown)}
   end
@@ -128,7 +154,7 @@ defmodule Ms2ex.Managers.Character do
   # --------------------------------
 
   def handle_cast({:consume_stat, stat_id, amount}, character) do
-    {:noreply, Character.Stats.decrease(character, stat_id, amount)}
+    {:noreply, Character.Stats.decrease(character, stat_id, amount, [])}
   end
 
   def handle_cast({:set_stat, stat_id, amount}, character) do
@@ -184,6 +210,9 @@ defmodule Ms2ex.Managers.Character do
 
   def handle_info({:regen, stat_id}, character),
     do: {:noreply, Character.Stats.regen(character, stat_id)}
+
+  def handle_info({:state_skill_tick, cast_id}, character),
+    do: {:noreply, Character.Skill.state_skill_tick(character, cast_id)}
 
   def handle_info({:DOWN, _, _, _pid, _reason}, character) do
     cleanup(character)

--- a/lib/ms2ex/managers/character/skill.ex
+++ b/lib/ms2ex/managers/character/skill.ex
@@ -4,6 +4,7 @@ defmodule Ms2ex.Managers.Character.Skill do
 
   alias Ms2ex.Managers
   alias Ms2ex.Managers.Character
+  alias Ms2ex.Packets
 
   def cast_skill(%{stats: stats} = character, skill_cast) do
     spirit_cost = Types.SkillCast.spirit_cost(skill_cast)
@@ -47,6 +48,121 @@ defmodule Ms2ex.Managers.Character.Skill do
     |> Character.Stats.decrease(:spirit, spirit_cost, broadcast: false)
     |> Character.Stats.decrease(:stamina, stamina_cost, broadcast: false)
   end
+
+  # --------------------------------
+  # State skills
+  # --------------------------------
+
+  # a state skill (toggle/stance) is cast repeatedly for as long as it is
+  # active: the cast is gated on having enough resources and every drain tick
+  # re-validates and consumes again. Cancelled when resources run out, the
+  # actor dies, the actor leaves the skill's movement state, or a replacement
+  # state skill arrives.
+  def cast_state_skill(%{stats: stats} = character, skill_cast, _state) do
+    spirit_cost = Types.SkillCast.spirit_cost(skill_cast)
+    stamina_cost = Types.SkillCast.stamina_cost(skill_cast)
+
+    if stats.spirit_cur >= spirit_cost && stats.stamina_cur >= stamina_cost do
+      Managers.SkillCast.start_link(skill_cast)
+
+      character =
+        character
+        |> Character.Stats.decrease(:spirit, spirit_cost, broadcast: false)
+        |> Character.Stats.decrease(:stamina, stamina_cost, broadcast: false)
+
+      {:ok, character}
+    else
+      :error
+    end
+  end
+
+  # arms the drain loop for a freshly accepted state-skill cast; any
+  # previously active state skill is cancelled first so an actor holds at
+  # most one at a time. Runs inside the character manager (the loop's owner).
+  def activate_state_skill(character, skill_cast, state) do
+    character = cancel_state_skill(character)
+
+    Process.send_after(
+      self(),
+      {:state_skill_tick, skill_cast.id},
+      Types.SkillCast.drain_interval(skill_cast)
+    )
+
+    Map.put(character, :state_skill, %{skill_cast: skill_cast, state: state})
+  end
+
+  # a drain tick for a cast that is no longer the active one is stale and
+  # just dies out
+  def state_skill_tick(%{state_skill: %{skill_cast: %{id: active_id}}} = character, cast_id)
+      when active_id == cast_id do
+    drain_state_skill(character, character.state_skill)
+  end
+
+  def state_skill_tick(character, _stale_cast_id), do: character
+
+  defp drain_state_skill(%{dead?: true} = character, _active),
+    do: cancel_state_skill(character)
+
+  defp drain_state_skill(character, active) do
+    skill_cast = active.skill_cast
+    spirit_cost = Types.SkillCast.spirit_cost(skill_cast)
+    stamina_cost = Types.SkillCast.stamina_cost(skill_cast)
+    stats = character.stats
+
+    cond do
+      # the actor left the skill's movement state (e.g. released the swim
+      # boost): the state-synced actor state no longer matches
+      left_skill_state?(character, skill_cast) ->
+        cancel_state_skill(character)
+
+      stats.spirit_cur < spirit_cost or stats.stamina_cur < stamina_cost ->
+        # resources exhausted: drop the stance so the drain cannot go negative
+        cancel_state_skill(character)
+
+      true ->
+        character =
+          character
+          |> Character.Stats.decrease(:spirit, spirit_cost, [])
+          |> Character.Stats.decrease(:stamina, stamina_cost, [])
+
+        Process.send_after(
+          self(),
+          {:state_skill_tick, skill_cast.id},
+          Types.SkillCast.drain_interval(skill_cast)
+        )
+
+        character
+    end
+  end
+
+  # state skills carry the ActorState they put the actor in; user syncs keep
+  # the actor's current state and a mismatch means the movement ended
+  defp left_skill_state?(character, skill_cast) do
+    expected = skill_cast.meta[:state][:state] || 0
+    expected != 0 and Map.get(character, :animation, 0) != expected
+  end
+
+  # server-side cancel: stops the drain loop, drops the cast, and tells the
+  # field the actor left the skill state (state 0). The client keeps its own
+  # stance UI until it observes the resource drain.
+  def cancel_state_skill(%{state_skill: nil} = character), do: character
+
+  def cancel_state_skill(%{state_skill: active} = character) when active != nil do
+    skill_cast = active.skill_cast
+    character = Map.put(character, :state_skill, nil)
+
+    Managers.SkillCast.stop(skill_cast.id)
+
+    Context.Field.broadcast(
+      character,
+      Packets.StateSkill.bytes(character, skill_cast.skill_id, skill_cast.id, 0)
+    )
+
+    character
+  end
+
+  # character state predating the state-skill tracking: nothing to cancel
+  def cancel_state_skill(character), do: character
 
   defp apply_status(character, buff) do
     modifiers = Types.Buff.stat_modifiers(buff, character)

--- a/lib/ms2ex/managers/character/stats.ex
+++ b/lib/ms2ex/managers/character/stats.ex
@@ -3,8 +3,18 @@ defmodule Ms2ex.Managers.Character.Stats do
   alias Ms2ex.Context
   alias Ms2ex.Managers.Character
   alias Ms2ex.Packets
+  alias Ms2ex.Storage.Tables
 
   @regen_stats %{health: :hp, spirit: :sp, stamina: :stamina}
+
+  # server constants that suspend a stat's passive regen after consuming it;
+  # the fallback matches the live constants table values
+  @regen_wait_keys %{
+    health: :recovery_hp_wait_tick,
+    spirit: :recovery_sp_wait_tick,
+    stamina: :recovery_ep_wait_tick
+  }
+  @default_regen_wait 1_000
 
   def decrease(character, stats, opts \\ []) do
     Enum.reduce(stats, character, fn {stat, amount}, character ->
@@ -14,7 +24,27 @@ defmodule Ms2ex.Managers.Character.Stats do
 
   def decrease(character, stat_id, amount, opts) do
     cur = Map.get(character.stats, :"#{stat_id}_cur")
+    character = defer_regen(character, stat_id)
     set(character, stat_id, cur - amount, opts)
+  end
+
+  # every consumption pushes the stat's regen deadline back; regen resumes
+  # the stat's Recovery*WaitTick after the last consumption
+  defp defer_regen(character, stat_id) do
+    if Map.has_key?(@regen_stats, stat_id) do
+      waits = Map.get(character, :regen_waits, %{})
+      deadline = System.monotonic_time(:millisecond) + regen_wait(stat_id)
+      Map.put(character, :regen_waits, Map.put(waits, stat_id, deadline))
+    else
+      character
+    end
+  end
+
+  defp regen_wait(stat_id) do
+    case Map.get(@regen_wait_keys, stat_id) do
+      nil -> @default_regen_wait
+      key -> Tables.Constants.get(key) || @default_regen_wait
+    end
   end
 
   def increase(character, stats) do
@@ -90,10 +120,31 @@ defmodule Ms2ex.Managers.Character.Stats do
     end
   end
 
-  def regen(%{dead?: false} = character, stat_id),
+  # the dead do not regenerate; the living regen one tick per scheduled
+  # message until the stat is full or the actor dies
+  def regen(%{dead?: true} = character, stat_id),
     do: Map.put(character, :"regen_#{stat_id}?", false)
 
-  def regen(%{stats: stats} = character, stat_id) do
+  def regen(character, stat_id) do
+    case regen_remaining_wait(character, stat_id) do
+      rest when rest > 0 ->
+        # consumption suspended this stat's regen; wake when the wait expires
+        Process.send_after(self(), {:regen, stat_id}, rest)
+        Map.put(character, :"regen_#{stat_id}?", true)
+
+      _ ->
+        regen_tick(character, stat_id)
+    end
+  end
+
+  defp regen_remaining_wait(character, stat_id) do
+    case Map.get(Map.get(character, :regen_waits, %{}), stat_id) do
+      nil -> 0
+      deadline -> deadline - System.monotonic_time(:millisecond)
+    end
+  end
+
+  defp regen_tick(%{stats: stats} = character, stat_id) do
     intval = Map.get(character.stats, :"#{@regen_stats[stat_id]}_regen_interval_cur")
     cur = Map.get(character.stats, :"#{stat_id}_cur")
     max = Map.get(character.stats, :"#{stat_id}_max")

--- a/lib/ms2ex/managers/skill_cast.ex
+++ b/lib/ms2ex/managers/skill_cast.ex
@@ -15,8 +15,24 @@ defmodule Ms2ex.Managers.SkillCast do
     end
   end
 
+  # idempotent: a cast uid may legitimately arrive through more than one
+  # channel (e.g. SkillUse and StateSkill), and the second registration must
+  # not tear down the session
   def start_link(%SkillCast{} = skill_cast) do
-    Agent.start_link(fn -> skill_cast end, name: process_name(skill_cast.id))
+    case Agent.start_link(fn -> skill_cast end, name: process_name(skill_cast.id)) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, {:already_started, _pid}} ->
+        {:ok, process_name(skill_cast.id)}
+    end
+  end
+
+  def stop(skill_cast_id) do
+    case Process.whereis(process_name(skill_cast_id)) do
+      nil -> :ok
+      pid -> Agent.stop(pid)
+    end
   end
 
   def update(%SkillCast{} = skill_cast, attrs) do

--- a/lib/ms2ex/storage/table/constants.ex
+++ b/lib/ms2ex/storage/table/constants.ex
@@ -1,0 +1,17 @@
+defmodule Ms2ex.Storage.Tables.Constants do
+  alias Ms2ex.Storage
+
+  @table_name "server.constants.xml"
+
+  @doc """
+  Returns the value of a server constant (snake_case atom, e.g.
+  :recovery_ep_wait_tick), or nil when the table or key is absent.
+  """
+  @spec get(atom()) :: term() | nil
+  def get(key) when is_atom(key) do
+    case Storage.get(:table, @table_name) do
+      %{} = constants -> Map.get(constants, key)
+      _ -> nil
+    end
+  end
+end

--- a/lib/ms2ex/types/skill_cast.ex
+++ b/lib/ms2ex/types/skill_cast.ex
@@ -3,6 +3,8 @@ defmodule Ms2ex.Types.SkillCast do
   alias Ms2ex.Enums
   alias Ms2ex.Types.Coord
 
+  @state_skill_drain_interval 1000
+
   @type t :: %__MODULE__{}
   defstruct [
     :client_tick,
@@ -64,6 +66,20 @@ defmodule Ms2ex.Types.SkillCast do
     case splash(skill_cast) do
       %{interval: interval} -> interval
       _ -> 0
+    end
+  end
+
+  # cadence for a state skill's resource drain: the motion sequence speed in
+  # milliseconds when projected, otherwise once per second. The fallback also
+  # covers metadata ingested before motion_property was projected.
+  def drain_interval(%__MODULE__{} = skill_cast) do
+    case skill_level(skill_cast) do
+      %{motions: [%{motion_property: %{sequence_speed: speed}} | _]}
+      when is_number(speed) and speed > 0 ->
+        trunc(speed * 1000)
+
+      _ ->
+        @state_skill_drain_interval
     end
   end
 

--- a/test/ms2ex/state_skill_cost_test.exs
+++ b/test/ms2ex/state_skill_cost_test.exs
@@ -1,0 +1,297 @@
+defmodule Ms2ex.StateSkillCostTest do
+  use ExUnit.Case, async: true
+
+  alias Ms2ex.Managers
+  alias Ms2ex.Managers.Character
+  alias Ms2ex.Schema
+  alias Ms2ex.Types
+
+  @cast_id 9001
+  @drain_cost %{spirit: 10, stamina: 5}
+
+  # ---- cast gating & consumption ----
+
+  test "cast_state_skill consumes spirit and stamina" do
+    character = character()
+    skill_cast = skill_cast(character)
+
+    assert {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    assert character.stats.spirit_cur == 90
+    assert character.stats.stamina_cur == 95
+  end
+
+  test "cast_state_skill is rejected without enough resources" do
+    character = character(%{stats: %{spirit_cur: 5, spirit_max: 100}})
+    skill_cast = skill_cast(character)
+
+    assert :error = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    assert character.stats.spirit_cur == 5
+  end
+
+  # ---- drain ticks ----
+
+  test "state_skill_tick drains again while resources last" do
+    character = character()
+    skill_cast = skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    character = activate(character, skill_cast, 16)
+
+    character = Character.Skill.state_skill_tick(character, @cast_id)
+
+    assert character.stats.spirit_cur == 80
+    assert character.stats.stamina_cur == 90
+    assert character.state_skill.skill_cast.id == @cast_id
+  end
+
+  test "state_skill_tick cancels the stance when resources run out" do
+    character = character()
+    skill_cast = skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    character = activate(character, skill_cast, 16)
+    character = put_in(character.stats.spirit_cur, 3)
+
+    character = Character.Skill.state_skill_tick(character, @cast_id)
+
+    assert character.state_skill == nil
+    assert character.stats.spirit_cur == 3
+  end
+
+  test "state_skill_tick cancels the stance when the actor is dead" do
+    character = character()
+    skill_cast = skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    character = activate(character, skill_cast, 16)
+    character = Map.put(character, :dead?, true)
+
+    character = Character.Skill.state_skill_tick(character, @cast_id)
+
+    assert character.state_skill == nil
+  end
+
+  test "state_skill_tick drains while the synced actor state matches" do
+    character = character()
+    skill_cast = swim_skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 28)
+    character = activate(character, skill_cast, 28)
+    character = Map.put(character, :animation, 28)
+
+    character = Character.Skill.state_skill_tick(character, @cast_id)
+
+    # cast consumed 5, the tick drains another 5
+    assert character.stats.stamina_cur == 90
+    assert character.state_skill.skill_cast.id == @cast_id
+  end
+
+  test "state_skill_tick cancels once the actor leaves the skill state" do
+    character = character()
+    skill_cast = swim_skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 28)
+    character = activate(character, skill_cast, 28)
+    character = Map.put(character, :animation, 28)
+
+    # the actor released the boost: user syncs no longer report swimming
+    character = Map.put(character, :animation, 0)
+
+    character = Character.Skill.state_skill_tick(character, @cast_id)
+
+    assert character.state_skill == nil
+    assert character.stats.stamina_cur == 95
+  end
+
+  test "state_skill_tick ignores stale cast ids" do
+    character = character()
+    skill_cast = skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    character = activate(character, skill_cast, 16)
+
+    character = Character.Skill.state_skill_tick(character, @cast_id + 1)
+
+    assert character.stats.spirit_cur == 90
+    assert character.state_skill.skill_cast.id == @cast_id
+  end
+
+  # ---- cancellation ----
+
+  test "cancel_state_skill drops the active stance" do
+    character = character()
+    skill_cast = skill_cast(character)
+
+    {:ok, character} = Character.Skill.cast_state_skill(character, skill_cast, 16)
+    character = activate(character, skill_cast, 16)
+
+    cancelled = Character.Skill.cancel_state_skill(character)
+
+    assert %{state_skill: nil} = cancelled
+    # the cast manager is stopped with the stance
+    assert Process.whereis(:"skill_cast:#{@cast_id}") == nil
+  end
+
+  test "cancel_state_skill tolerates missing state-skill tracking" do
+    # a character whose manager state predates the tracking has no key
+    character = character()
+    refute Map.has_key?(character, :state_skill)
+    assert character == Character.Skill.cancel_state_skill(character)
+  end
+
+  # ---- integration: the character manager owns the drain loop ----
+
+  test "the character manager validates, consumes, and refreshes without double-drain" do
+    character = character(%{id: System.unique_integer([:positive])})
+    {:ok, pid} = Managers.Character.start(character)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    skill_cast = skill_cast(character)
+
+    assert {:ok, first} =
+             Managers.Character.call(character, {:cast_state_skill, skill_cast, 16})
+
+    assert first.stats.spirit_cur == 90
+
+    # a repeated packet for the same stance must not consume again
+    assert {:ok, refreshed} =
+             Managers.Character.call(character, {:cast_state_skill, skill_cast, 16})
+
+    assert refreshed.stats.spirit_cur == 90
+
+    # a new stance on a different cast id replaces the running one
+    other = skill_cast(character, @cast_id + 7)
+
+    assert {:ok, switched} = Managers.Character.call(character, {:cast_state_skill, other, 16})
+    assert switched.stats.spirit_cur == 80
+  end
+
+  test "the character manager rejects a state-skill cast without resources" do
+    character =
+      character(%{
+        id: System.unique_integer([:positive]),
+        stats: %{
+          spirit_max: 100,
+          spirit_cur: 0,
+          stamina_max: 100,
+          stamina_cur: 100,
+          sp_regen_interval_cur: 1000,
+          stamina_regen_interval_cur: 1000,
+          hp_regen_interval_cur: 1000
+        }
+      })
+
+    {:ok, pid} = Managers.Character.start(character)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    assert :error =
+             Managers.Character.call(character, {:cast_state_skill, skill_cast(character), 16})
+  end
+
+  # ---- drain cadence ----
+
+  test "drain_interval uses the projected motion sequence speed" do
+    skill_cast = %Types.SkillCast{
+      skill_id: 15_000_220,
+      skill_level: 1,
+      meta: %{
+        levels: %{
+          "1" => %{
+            consume: %{stat: @drain_cost},
+            motions: [%{motion_property: %{sequence_speed: 0.6}, attacks: []}]
+          }
+        }
+      }
+    }
+
+    assert Types.SkillCast.drain_interval(skill_cast) == 600
+  end
+
+  test "drain_interval falls back without projected sequence speed" do
+    skill_cast = %Types.SkillCast{
+      skill_id: 15_000_220,
+      skill_level: 1,
+      meta: %{levels: %{"1" => %{consume: %{stat: @drain_cost}, motions: [%{attacks: []}]}}}
+    }
+
+    assert Types.SkillCast.drain_interval(skill_cast) == 1000
+  end
+
+  test "drain_interval falls back on zero speed or missing motions" do
+    zero = %Types.SkillCast{
+      skill_id: 15_000_220,
+      skill_level: 1,
+      meta: %{
+        levels: %{
+          "1" => %{
+            consume: %{stat: @drain_cost},
+            motions: [%{motion_property: %{sequence_speed: 0.0}, attacks: []}]
+          }
+        }
+      }
+    }
+
+    assert Types.SkillCast.drain_interval(zero) == 1000
+
+    motionless = %Types.SkillCast{
+      skill_id: 15_000_220,
+      skill_level: 1,
+      meta: %{levels: %{"1" => %{consume: %{stat: @drain_cost}}}}
+    }
+
+    assert Types.SkillCast.drain_interval(motionless) == 1000
+  end
+
+  # ---- helpers ----
+
+  defp character(overrides \\ %{}) do
+    stats = %{
+      health_max: 1000,
+      health_cur: 1000,
+      spirit_max: 100,
+      spirit_cur: 100,
+      stamina_max: 100,
+      stamina_cur: 100,
+      sp_regen_interval_cur: 1000,
+      stamina_regen_interval_cur: 1000,
+      hp_regen_interval_cur: 1000
+    }
+
+    %Schema.Character{
+      id: System.unique_integer([:positive]),
+      object_id: System.unique_integer([:positive]),
+      map_id: 2000,
+      channel_id: 1,
+      sender_session_pid: self(),
+      stats: stats
+    }
+    |> Map.merge(overrides)
+  end
+
+  defp skill_cast(caster, id \\ @cast_id) do
+    %Types.SkillCast{
+      id: id,
+      skill_id: 15_000_220,
+      skill_level: 1,
+      caster: caster,
+      meta: %{levels: %{"1" => %{consume: %{stat: @drain_cost}}}}
+    }
+  end
+
+  defp swim_skill_cast(caster) do
+    %Types.SkillCast{
+      id: @cast_id,
+      skill_id: 20_000_001,
+      skill_level: 1,
+      caster: caster,
+      meta: %{
+        state: %{state: 28},
+        levels: %{"1" => %{consume: %{stat: %{stamina: 5}}}}
+      }
+    }
+  end
+
+  defp activate(character, skill_cast, state) do
+    Map.put(character, :state_skill, %{skill_cast: skill_cast, state: state})
+  end
+end

--- a/test/ms2ex/stats_regen_test.exs
+++ b/test/ms2ex/stats_regen_test.exs
@@ -1,0 +1,171 @@
+defmodule Ms2ex.StatsRegenTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Ms2ex.Managers
+  alias Ms2ex.Managers.Character
+  alias Ms2ex.Schema
+
+  @interval 50
+  @regen 10
+
+  test "regen applies the regen amount to a living character below max" do
+    character = character(stats: [stamina_cur: 40, stamina_max: 100])
+
+    character = Character.Stats.regen(character, :stamina)
+
+    assert character.stats.stamina_cur == 50
+    assert character.regen_stamina? == true
+  end
+
+  test "regen stops once the stat is full" do
+    character = character(stats: [stamina_cur: 95, stamina_max: 100])
+
+    # first tick tops off (and schedules one more); the next tick is a no-op
+    character = Character.Stats.regen(character, :stamina)
+    assert character.stats.stamina_cur == 100
+
+    character = Character.Stats.regen(character, :stamina)
+    assert character.stats.stamina_cur == 100
+    assert character.regen_stamina? == false
+  end
+
+  test "the dead do not regenerate" do
+    character =
+      character(stats: [stamina_cur: 40, stamina_max: 100])
+      |> Map.put(:dead?, true)
+
+    character = Character.Stats.regen(character, :stamina)
+
+    assert character.stats.stamina_cur == 40
+    assert character.regen_stamina? == false
+  end
+
+  test "regen caps at max" do
+    character = character(stats: [stamina_cur: 97, stamina_max: 100])
+
+    assert Character.Stats.regen(character, :stamina).stats.stamina_cur == 100
+  end
+
+  test "consumption suspends regen for the wait period" do
+    character = character(stats: [stamina_cur: 100, stamina_max: 100])
+    character = Character.Stats.decrease(character, :stamina, 40, [])
+
+    assert character.stats.stamina_cur == 60
+    assert Map.has_key?(character.regen_waits, :stamina)
+
+    # the regen tick inside the wait window is deferred, not lost
+    character = Character.Stats.regen(character, :stamina)
+
+    assert character.stats.stamina_cur == 60
+    assert character.regen_stamina? == true
+  end
+
+  test "regen resumes once the wait expires" do
+    character = character(stats: [stamina_cur: 60, stamina_max: 100])
+    character = Character.Stats.decrease(character, :stamina, 10, [])
+    assert character.stats.stamina_cur == 50
+
+    # pretend the wait already elapsed
+    character =
+      Map.put(character, :regen_waits, %{
+        stamina: System.monotonic_time(:millisecond) - 1
+      })
+
+    character = Character.Stats.regen(character, :stamina)
+
+    assert character.stats.stamina_cur == 60
+  end
+
+  test "the character manager resumes regen after a stamina drain" do
+    character = character(id: System.unique_integer([:positive]), stats: [stamina_cur: 100])
+    {:ok, pid} = Managers.Character.start(character)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    Managers.Character.cast(character, {:consume_stat, :stamina, 40})
+    assert {:ok, %{stats: %{stamina_cur: 60}}} = Managers.Character.call(character, :lookup)
+
+    # the regen cycle re-arms itself until the stat is full
+    regen_to = eventually(fn -> stamina_of(character) end, &(&1 >= 100), 5_000)
+
+    assert regen_to == 100
+  end
+
+  defp stamina_of(character) do
+    case Managers.Character.call(character, :lookup) do
+      {:ok, %{stats: %{stamina_cur: cur}}} -> cur
+      _ -> -1
+    end
+  end
+
+  defp eventually(produce, done?, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_eventually(produce, done?, deadline)
+  end
+
+  defp do_eventually(produce, done?, deadline) do
+    value = produce.()
+
+    if done?.(value) or System.monotonic_time(:millisecond) > deadline do
+      value
+    else
+      Process.sleep(25)
+      do_eventually(produce, done?, deadline)
+    end
+  end
+
+  test "regen wait comes from the server constants table" do
+    Mimic.stub(Ms2ex.Storage, :get, fn :table, "server.constants.xml" ->
+      %{recovery_ep_wait_tick: 250}
+    end)
+
+    before = System.monotonic_time(:millisecond)
+    character = character(stats: [stamina_cur: 100, stamina_max: 100])
+    character = Character.Stats.decrease(character, :stamina, 40, [])
+
+    assert character.regen_waits.stamina in (before + 250)..(System.monotonic_time(:millisecond) +
+                                                               250)
+  end
+
+  test "regen wait falls back when the constants table is absent" do
+    Mimic.stub(Ms2ex.Storage, :get, fn :table, "server.constants.xml" -> nil end)
+
+    before = System.monotonic_time(:millisecond)
+    character = character(stats: [stamina_cur: 100, stamina_max: 100])
+    character = Character.Stats.decrease(character, :stamina, 40, [])
+
+    assert character.regen_waits.stamina in (before + 1_000)..(System.monotonic_time(:millisecond) +
+                                                                 1_000)
+  end
+
+  defp character(overrides) do
+    {stat_overrides, overrides} = Keyword.pop(overrides, :stats, [])
+
+    stats =
+      %{
+        health_max: 1000,
+        health_cur: 1000,
+        hp_regen_cur: 5,
+        hp_regen_interval_cur: @interval,
+        spirit_max: 100,
+        spirit_cur: 100,
+        sp_regen_cur: 5,
+        sp_regen_interval_cur: @interval,
+        stamina_max: 100,
+        stamina_cur: 100,
+        stamina_regen_cur: @regen,
+        stamina_regen_interval_cur: @interval
+      }
+      |> Map.merge(Map.new(stat_overrides))
+
+    %Schema.Character{
+      id: System.unique_integer([:positive]),
+      object_id: System.unique_integer([:positive]),
+      map_id: 2000,
+      channel_id: 1,
+      sender_session_pid: self(),
+      stats: stats
+    }
+    |> Map.merge(Map.new(overrides))
+  end
+end


### PR DESCRIPTION
## What

Closes roadmap item 5 (Skill resource costs — P2):

- **State skills (recv `0x21`) now validate and consume SP/stamina on cast** (previously they consumed nothing), relay only on success, and broadcast a full stat refresh
- An accepted cast arms a **per-tick drain loop** on the character manager: every tick re-validates and consumes again, at the cadence of the projected motion `sequence_speed` (fallback 1s for pre-projection metadata)
- The drain **cancels** when the actor leaves the skill's movement state (user syncs carry the actor state — e.g. releasing Ctrl ends Swift Swim), the actor dies, resources run out, or a replacement state skill arrives
- Repeated packets for the same cast id + state refresh without double-consuming; an actor holds at most one state skill at a time

## Regen fixes (exposed by the swim test)

- `Character.Stats.regen/2` had an inverted `dead?` guard since #88: living characters returned early and **never regenerated** HP/SP/stamina
- Consumption now suspends that stat's regen for the projected `Recovery*WaitTick` — read from the new `server.constants.xml` ingest doc, 1s fallback — matching the reference. Swift Swim (20 stamina / ~0.9s) depletes stamina while boosting and regen resumes ~1s after release
- `Managers.Character`'s `{:consume_stat, ...}` cast called the broken 3-arity `Stats.decrease` (crashed the manager); fixed

## Ingest dependency

Requires the ingest commit `a6b67c7` (projects `motion_property` on skill motions and the server constants table). Without re-ingesting, the code still works via 1s fallbacks.

## Verification

- 123 tests passing (new: state-skill gating/drain/cancel/refresh, drain cadence from metadata, regen ticks, regen-wait suspension + fallback)
- credo clean, formatted
- In-game: Swift Swim drains 20 stamina per ~0.9s while Ctrl is held, depletes the bar on long boosts, cancels on release/exhaustion, regen resumes ~1s later; passive swimming costs nothing (matches metadata)