### PR TITLE
Fix region skill rotation and spirit regen parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,10 @@ re-ingesting (`docker compose run --rm ms2ex-file-ingest --probe-...`):
   blocks.** Copying a module there lets every test stub it; test files only
   call `Mimic.stub`. If a test needs to stub a module that isn't copied yet,
   add the `Mimic.copy` to `test_helper.exs` first.
+- **Do not seed metadata in tests by writing directly to ETS.** Use the
+  shared `stub_metadata/1` helper from `test/support/test_helpers.ex` instead
+  of `:ets.insert(:metadata, ...)` so tests go through the same storage stub
+  path consistently.
 
 ## Architecture notes
 
@@ -92,8 +96,9 @@ re-ingesting (`docker compose run --rm ms2ex-file-ingest --probe-...`):
 
 - **Update `docs/ROADMAP.md` whenever you touch a feature.** When an item is
   implemented, fixed, or advances, update its `[Open]` / `[Partial]` status or
-  move it into "Recently completed". Keep the roadmap the source of truth for
-  what is still missing.
+  move it into "Recently completed". Completed items must be moved out of the
+  numbered backlog sections into "Recently completed". Keep the roadmap the
+  source of truth for what is still missing.
 - **Leave `TODO` comments for unimplemented behavior.** When a code path is
   incomplete or stubbed, add a `# TODO` comment (with a short note on what
   remains) so unfinished work can be found by grepping for `TODO`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,10 @@ re-ingesting (`docker compose run --rm ms2ex-file-ingest --probe-...`):
 - **Never commit without explicit approval.** Implement changes, compile,
   and verify, but leave them uncommitted so the user can test against the
   game client first. Commit only after the user confirms the fix works.
+- **Before merging and cleaning up a worktree, do a final review against the
+  reference behavior.** Re-check the full diff, look for refactor
+  opportunities, and confirm the implemented behavior matches the reference as
+  closely as possible before the branch is merged or the worktree is removed.
 
 - `lib/ms2ex/storage.ex` is a lazy, immutable cache: documents are fetched
   from Redis on first access into the `:metadata` ETS table and never

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,4 +16,4 @@ config :logger, level: :warning
 # the game/login TCP listeners never start under test
 config :ms2ex, :start_game_servers, false
 
-config :ms2ex, Oban, plugins: false, queues: false, peer: false
+config :ms2ex, Oban, testing: :manual, plugins: false

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,9 +98,10 @@ The drop packet still has three deviations:
 still uses a fixed radius instead of the exact skill geometry and always lands
 the first hit immediately.
 
-### 11. RegionSkill rotation — [Open]
+### 11. RegionSkill rotation — [Done]
 
-`RegionSkill` always sends rotation where direction-less skills should zero it.
+`RegionSkill` now zeros horizontal rotation for direction-less region skills while
+keeping directional ones unchanged.
 
 ### 12. Party damage meter — [Open]
 
@@ -119,9 +120,13 @@ damage accumulation + `DpsStat` flow (see `docs/internal/party-dps-meter.md`).
 - Passive HP/SP/stamina regen fix: inverted dead-actor guard on
   `Character.Stats.regen/2` (from #88) meant living characters never
   regenerated; exposed by the Swift Swim stamina drain. Consumption now
-  also suspends that stat's regen for the projected Recovery*WaitTick
+  also suspends HP/stamina regen for the projected Recovery*WaitTick
   (new server.constants.xml ingest doc), so drains deplete instead of
-  racing regen ([#98](https://github.com/sgessa/ms2ex/pull/98))
+  racing regen. Regular active-skill SP drains now persist in the
+  character manager too, so spirit regen resumes after normal casts as
+  well as state skills; passive regen ticks now also clamp to a minimum
+  interval so negative rate bonuses cannot collapse them to zero delay
+  ([#98](https://github.com/sgessa/ms2ex/pull/98))
 - State-skill resource costs: cast validation + consumption, per-tick drain
   loop at the projected motion `sequence_speed`, cancellation on state
   mismatch / death / resource exhaustion

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,11 +98,6 @@ The drop packet still has three deviations:
 still uses a fixed radius instead of the exact skill geometry and always lands
 the first hit immediately.
 
-### 11. RegionSkill rotation — [Done]
-
-`RegionSkill` now zeros horizontal rotation for direction-less region skills while
-keeping directional ones unchanged.
-
 ### 12. Party damage meter — [Open]
 
 The client's party DPS meter never updates because the server never feeds it.
@@ -117,6 +112,10 @@ damage accumulation + `DpsStat` flow (see `docs/internal/party-dps-meter.md`).
 
 ## Recently completed
 
+- RegionSkill rotation: direction-less region skills now zero horizontal
+  rotation while directional ones keep it; region-splash damage no longer
+  crashes on hit, and regular-skill spirit drains now persist so Wizard SP
+  regen matches observed timing (immediate start, minimum 100ms tick floor)
 - Passive HP/SP/stamina regen fix: inverted dead-actor guard on
   `Character.Stats.regen/2` (from #88) meant living characters never
   regenerated; exposed by the Swift Swim stamina drain. Consumption now

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,7 +96,9 @@ The drop packet still has three deviations:
 
 `ImmediateActive` / `Delay` are now projected by the ingest, but the server
 still uses a fixed radius instead of the exact skill geometry and always lands
-the first hit immediately.
+the first hit immediately. Cube-magic-path placement also still has parity
+work left: rotated `fire_offset` is applied, but source-height alignment and
+`ignore_adjust` snapping are not matched yet.
 
 ### 12. Party damage meter — [Open]
 

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -36,9 +36,9 @@ defmodule Ms2ex.Managers.Character do
   def init(character) do
     {:ok,
      character
-     |> Map.put(:regen_hp?, false)
-     |> Map.put(:regen_sp?, false)
-     |> Map.put(:regen_sta?, false)
+     |> Map.put(:regen_health?, false)
+     |> Map.put(:regen_spirit?, false)
+     |> Map.put(:regen_stamina?, false)
      |> Map.put(:skill_cooldowns, %{})
      |> Map.put(:state_skill, nil)
      |> Map.put(:regen_waits, %{})
@@ -66,6 +66,9 @@ defmodule Ms2ex.Managers.Character do
       |> Map.put(:instant_revive_count, Map.get(state, :instant_revive_count, 0))
       |> Map.put(:state_skill, Map.get(state, :state_skill))
       |> Map.put(:regen_waits, Map.get(state, :regen_waits, %{}))
+      |> Map.put(:regen_health?, Map.get(state, :regen_health?, false))
+      |> Map.put(:regen_spirit?, Map.get(state, :regen_spirit?, false))
+      |> Map.put(:regen_stamina?, Map.get(state, :regen_stamina?, false))
 
     {:reply, :ok, updated}
   end
@@ -110,7 +113,8 @@ defmodule Ms2ex.Managers.Character do
   # --------------------------------
 
   def handle_call({:cast_skill, skill_cast}, _from, character) do
-    {:reply, {:ok, Character.Skill.cast_skill(character, skill_cast)}, character}
+    character = Character.Skill.cast_skill(character, skill_cast)
+    {:reply, {:ok, character}, character}
   end
 
   def handle_call({:cast_state_skill, skill_cast, state}, _from, character) do

--- a/lib/ms2ex/managers/character/stats.ex
+++ b/lib/ms2ex/managers/character/stats.ex
@@ -1,7 +1,8 @@
 defmodule Ms2ex.Managers.Character.Stats do
-  alias Ms2ex.Managers.PartyServer
   alias Ms2ex.Context
   alias Ms2ex.Managers.Character
+  alias Ms2ex.Managers.PartyServer
+  alias Ms2ex.Net
   alias Ms2ex.Packets
   alias Ms2ex.Storage.Tables
 
@@ -11,10 +12,10 @@ defmodule Ms2ex.Managers.Character.Stats do
   # the fallback matches the live constants table values
   @regen_wait_keys %{
     health: :recovery_hp_wait_tick,
-    spirit: :recovery_sp_wait_tick,
     stamina: :recovery_ep_wait_tick
   }
   @default_regen_wait 1_000
+  @min_regen_interval 100
 
   def decrease(character, stats, opts \\ []) do
     Enum.reduce(stats, character, fn {stat, amount}, character ->
@@ -31,7 +32,7 @@ defmodule Ms2ex.Managers.Character.Stats do
   # every consumption pushes the stat's regen deadline back; regen resumes
   # the stat's Recovery*WaitTick after the last consumption
   defp defer_regen(character, stat_id) do
-    if Map.has_key?(@regen_stats, stat_id) do
+    if Map.has_key?(@regen_wait_keys, stat_id) do
       waits = Map.get(character, :regen_waits, %{})
       deadline = System.monotonic_time(:millisecond) + regen_wait(stat_id)
       Map.put(character, :regen_waits, Map.put(waits, stat_id, deadline))
@@ -99,13 +100,18 @@ defmodule Ms2ex.Managers.Character.Stats do
     amount = amount |> max(0) |> min(total)
     stats = Map.put(character.stats, :"#{stat_id}_cur", amount)
     regen_stat = Map.get(@regen_stats, stat_id)
-
-    if regen_stat && !Map.get(character, :"regen_#{stat_id}?") && amount < total do
-      intval = Map.get(character.stats, :"#{regen_stat}_regen_interval_cur")
-      Process.send_after(self(), {:regen, stat_id}, intval)
-    end
+    regen_key = :"regen_#{stat_id}?"
 
     character = %{character | stats: stats}
+
+    character =
+      if regen_stat && !Map.get(character, regen_key, false) && amount < total do
+        intval = regen_interval(character.stats, regen_stat)
+        Process.send_after(self(), {:regen, stat_id}, intval)
+        Map.put(character, regen_key, true)
+      else
+        character
+      end
 
     if Keyword.get(opts, :broadcast, true) do
       broadcast_new_stats(character, stat_id)
@@ -145,13 +151,12 @@ defmodule Ms2ex.Managers.Character.Stats do
   end
 
   defp regen_tick(%{stats: stats} = character, stat_id) do
-    intval = Map.get(character.stats, :"#{@regen_stats[stat_id]}_regen_interval_cur")
+    regen_stat = @regen_stats[stat_id]
+    intval = regen_interval(character.stats, regen_stat)
     cur = Map.get(character.stats, :"#{stat_id}_cur")
     max = Map.get(character.stats, :"#{stat_id}_max")
 
     if cur < max do
-      regen_stat = @regen_stats[stat_id]
-
       stat_cur = Map.get(stats, :"#{stat_id}_cur")
       stat_max = Map.get(stats, :"#{stat_id}_max")
       regen = Map.get(stats, :"#{regen_stat}_regen_cur")
@@ -160,7 +165,7 @@ defmodule Ms2ex.Managers.Character.Stats do
       stats = Map.put(stats, :"#{stat_id}_cur", post_regen)
       character = %{character | stats: stats}
 
-      broadcast_new_stats(character, stat_id)
+      send_new_stats(character, stat_id)
       Process.send_after(self(), {:regen, stat_id}, intval)
 
       Map.put(character, :"regen_#{stat_id}?", true)
@@ -174,6 +179,20 @@ defmodule Ms2ex.Managers.Character.Stats do
 
     # the party HP packet must only be emitted when health itself changed;
     # spirit/stamina drains & regen fire constantly during combat
+    if stat_id == :health do
+      PartyServer.broadcast(character.party_id, Packets.Party.update_hitpoints(character))
+    end
+  end
+
+  defp regen_interval(stats, regen_stat) do
+    stats
+    |> Map.get(:"#{regen_stat}_regen_interval_cur")
+    |> max(@min_regen_interval)
+  end
+
+  defp send_new_stats(character, stat_id) do
+    Net.SenderSession.push(character, Packets.Stats.update_char_stats(character, [stat_id]))
+
     if stat_id == :health do
       PartyServer.broadcast(character.party_id, Packets.Party.update_hitpoints(character))
     end

--- a/lib/ms2ex/managers/field/buff.ex
+++ b/lib/ms2ex/managers/field/buff.ex
@@ -351,23 +351,7 @@ defmodule Ms2ex.Managers.Field.Buff do
         state
 
       {hp, _sp, _ep} ->
-        if hp > 0 and npc_alive?(state, buff.owner.object_id) do
-          {_reply, state} =
-            Managers.Field.Npc.damage(state, buff.caster, hp, buff.owner.object_id)
-
-          Context.Field.broadcast(
-            state.topic,
-            Packets.SkillDamage.dot_damage(%{
-              caster_id: buff.caster.object_id,
-              target_id: buff.owner.object_id,
-              proc_count: buff.proc_count,
-              type: 0,
-              hp_amount: -hp
-            })
-          )
-        end
-
-        state
+        apply_npc_dot_damage(buff, state, hp)
     end
   end
 
@@ -407,6 +391,33 @@ defmodule Ms2ex.Managers.Field.Buff do
         end
 
         state
+    end
+  end
+
+  defp apply_npc_dot_damage(_buff, state, hp) when hp <= 0, do: state
+
+  defp apply_npc_dot_damage(buff, state, hp) do
+    if npc_alive?(state, buff.owner.object_id) do
+      case Managers.Field.Npc.damage(state, buff.caster, hp, buff.owner.object_id) do
+        {:ok, _mob, state} ->
+          Context.Field.broadcast(
+            state.topic,
+            Packets.SkillDamage.dot_damage(%{
+              caster_id: buff.caster.object_id,
+              target_id: buff.owner.object_id,
+              proc_count: buff.proc_count,
+              type: 0,
+              hp_amount: -hp
+            })
+          )
+
+          state
+
+        {:error, state} ->
+          state
+      end
+    else
+      state
     end
   end
 

--- a/lib/ms2ex/managers/field/region_skill.ex
+++ b/lib/ms2ex/managers/field/region_skill.ex
@@ -9,11 +9,15 @@ defmodule Ms2ex.Managers.Field.RegionSkill do
 
   def add(skill_cast, state) do
     source_id = Ms2ex.generate_int()
-
-    Context.Field.broadcast(state.topic, Packets.RegionSkill.add(source_id, skill_cast))
+    points = SkillCast.magic_path(skill_cast)
 
     case SkillCast.splash_skill_cast(skill_cast) do
       {splash_cast, splash} ->
+        Context.Field.broadcast(
+          state.topic,
+          Packets.RegionSkill.add(source_id, splash_cast, points)
+        )
+
         interval = Map.get(splash, :interval, 0) || 0
         fires = max(Map.get(splash, :fire_count, 0) || 0, 1)
 
@@ -46,6 +50,11 @@ defmodule Ms2ex.Managers.Field.RegionSkill do
         state
 
       nil ->
+        Context.Field.broadcast(
+          state.topic,
+          Packets.RegionSkill.add(source_id, skill_cast, points)
+        )
+
         duration = SkillCast.duration(skill_cast)
         Process.send_after(self(), {:remove_region_skill, source_id}, duration + 5000)
         state

--- a/lib/ms2ex/managers/field/region_skill.ex
+++ b/lib/ms2ex/managers/field/region_skill.ex
@@ -13,10 +13,8 @@ defmodule Ms2ex.Managers.Field.RegionSkill do
 
     case SkillCast.splash_skill_cast(skill_cast) do
       {splash_cast, splash} ->
-        Context.Field.broadcast(
-          state.topic,
-          Packets.RegionSkill.add(source_id, splash_cast, points)
-        )
+        reg_skill = Packets.RegionSkill.add(source_id, splash_cast, points)
+        Context.Field.broadcast(state.topic, reg_skill)
 
         interval = Map.get(splash, :interval, 0) || 0
         fires = max(Map.get(splash, :fire_count, 0) || 0, 1)
@@ -41,19 +39,14 @@ defmodule Ms2ex.Managers.Field.RegionSkill do
             apply_splash(splash_cast, state)
           end
 
-        Process.send_after(
-          self(),
-          {:remove_region_skill, source_id},
-          max(end_tick - Ms2ex.sync_ticks(), 1)
-        )
+        delay = max(end_tick - Ms2ex.sync_ticks(), 1)
+        Process.send_after(self(), {:remove_region_skill, source_id}, delay)
 
         state
 
       nil ->
-        Context.Field.broadcast(
-          state.topic,
-          Packets.RegionSkill.add(source_id, skill_cast, points)
-        )
+        reg_skill = Packets.RegionSkill.add(source_id, skill_cast, points)
+        Context.Field.broadcast(state.topic, reg_skill)
 
         duration = SkillCast.duration(skill_cast)
         Process.send_after(self(), {:remove_region_skill, source_id}, duration + 5000)

--- a/lib/ms2ex/managers/field/region_skill.ex
+++ b/lib/ms2ex/managers/field/region_skill.ex
@@ -88,9 +88,15 @@ defmodule Ms2ex.Managers.Field.RegionSkill do
     {mobs, state} =
       Enum.reduce(targets, {[], state}, fn {object_id, mob}, {mobs, state} ->
         dmg = Context.Damage.calculate(splash_cast, mob, false)
-        {_reply, state} = Field.Npc.damage(state, splash_cast.caster, dmg.dmg, object_id)
-        state = Field.Npc.apply_skill_effects(state, splash_cast, object_id)
-        {[{mob, dmg} | mobs], state}
+
+        case Field.Npc.damage(state, splash_cast.caster, dmg.dmg, object_id) do
+          {:ok, damaged_mob, state} ->
+            state = Field.Npc.apply_skill_effects(state, splash_cast, object_id)
+            {[{damaged_mob, dmg} | mobs], state}
+
+          {:error, state} ->
+            {mobs, state}
+        end
       end)
 
     if mobs != [] do

--- a/lib/ms2ex/packets/game/region_skill.ex
+++ b/lib/ms2ex/packets/game/region_skill.ex
@@ -6,8 +6,8 @@ defmodule Ms2ex.Packets.RegionSkill do
 
   @modes %{add: 0x0, remove: 0x1}
 
-  def add(source_id, skill_cast) do
-    points = SkillCast.magic_path(skill_cast)
+  def add(source_id, skill_cast, points \\ nil) do
+    points = points || SkillCast.magic_path(skill_cast)
 
     __MODULE__
     |> build()

--- a/lib/ms2ex/packets/game/region_skill.ex
+++ b/lib/ms2ex/packets/game/region_skill.ex
@@ -22,9 +22,17 @@ defmodule Ms2ex.Packets.RegionSkill do
     |> put_int(skill_cast.skill_id)
     |> put_short(skill_cast.skill_level)
     # RotationH
-    |> put_float(skill_cast.rotation.z)
+    |> put_float(region_rotation_z(skill_cast))
     # RotationV / 100
     |> put_float()
+  end
+
+  defp region_rotation_z(skill_cast) do
+    if SkillCast.splash_use_direction?(skill_cast) do
+      skill_cast.rotation.z
+    else
+      0.0
+    end
   end
 
   def remove(source_id) do

--- a/lib/ms2ex/types/coord.ex
+++ b/lib/ms2ex/types/coord.ex
@@ -13,6 +13,16 @@ defmodule Ms2ex.Types.Coord do
     struct(__MODULE__, coord)
   end
 
+  def rotate(offset, %{z: rotation_z}) do
+    angle = rotation_z * :math.pi() / 180
+    offset = to_map(offset)
+
+    x = offset.x * :math.cos(angle) + offset.y * :math.sin(angle)
+    y = offset.x * :math.sin(angle) - offset.y * :math.cos(angle)
+
+    %__MODULE__{x: x, y: y, z: offset.z}
+  end
+
   defp to_map(%__MODULE__{} = coord), do: Map.from_struct(coord)
   defp to_map(coord), do: coord
 end

--- a/lib/ms2ex/types/skill_cast.ex
+++ b/lib/ms2ex/types/skill_cast.ex
@@ -144,12 +144,12 @@ defmodule Ms2ex.Types.SkillCast do
     end
   end
 
-  # the skill fired by a region/splash attack: the first condition skill of the
-  # attack carries the splash skill id+level; returns {cast, splash} so the
-  # region can be ticked at the splash interval
+  # the skill fired by a region/splash attack: returns the linked splash skill
+  # id+level plus its splash timing so the region can be announced and ticked
+  # with the correct metadata rather than a non-splash side effect listed first
   def splash_skill_cast(%__MODULE__{} = skill_cast) do
-    case attack_skills(skill_cast) do
-      [%{id: id, level: level, splash: splash} | _] when id > 0 ->
+    case splash_effect(skill_cast) do
+      %{id: id, level: level, splash: splash} when id > 0 ->
         cast = %__MODULE__{
           id: 0,
           skill_id: id,
@@ -175,15 +175,23 @@ defmodule Ms2ex.Types.SkillCast do
   end
 
   def splash(%__MODULE__{} = skill_cast) do
-    attack_skill = attack_point(skill_cast)[:skills] |> List.first()
-    attack_skill[:splash]
+    case splash_effect(skill_cast) do
+      %{splash: splash} -> splash
+      _ -> nil
+    end
   end
 
   def splash_use_direction?(%__MODULE__{} = skill_cast) do
-    case attack_skills(skill_cast) do
-      [%{splash: %{use_direction: false}} | _] -> false
+    case splash_effect(skill_cast) do
+      %{splash: %{use_direction: false}} -> false
       _ -> true
     end
+  end
+
+  defp splash_effect(%__MODULE__{} = skill_cast) do
+    skill_cast
+    |> attack_skills()
+    |> Enum.find(&(Map.get(&1, :has_splash, false) and is_map(Map.get(&1, :splash))))
   end
 
   def magic_path(%__MODULE__{} = skill_cast) do

--- a/lib/ms2ex/types/skill_cast.ex
+++ b/lib/ms2ex/types/skill_cast.ex
@@ -200,8 +200,7 @@ defmodule Ms2ex.Types.SkillCast do
     case Storage.Table.MagicPaths.get(cube_magic_path_id) do
       paths when is_list(paths) and paths != [] ->
         Enum.map(paths, fn path ->
-          # TODO fire_offset rotate if path.rotate?
-          fire_offset = struct(Coord, path[:fire_offset] || %{})
+          fire_offset = rotate_fire_offset(path, skill_cast.rotation)
           Coord.sum(skill_cast.position, fire_offset)
 
           # TODO align position unless path.ignoreAdjust
@@ -209,6 +208,16 @@ defmodule Ms2ex.Types.SkillCast do
 
       _ ->
         [skill_cast.position]
+    end
+  end
+
+  defp rotate_fire_offset(path, rotation) do
+    fire_offset = struct(Coord, path[:fire_offset] || %{})
+
+    if path[:rotate?] do
+      Coord.rotate(fire_offset, rotation)
+    else
+      fire_offset
     end
   end
 end

--- a/lib/ms2ex/types/skill_cast.ex
+++ b/lib/ms2ex/types/skill_cast.ex
@@ -179,6 +179,13 @@ defmodule Ms2ex.Types.SkillCast do
     attack_skill[:splash]
   end
 
+  def splash_use_direction?(%__MODULE__{} = skill_cast) do
+    case attack_skills(skill_cast) do
+      [%{splash: %{use_direction: false}} | _] -> false
+      _ -> true
+    end
+  end
+
   def magic_path(%__MODULE__{} = skill_cast) do
     cube_magic_path_id = attack_point(skill_cast)[:cube_magic_path_id] || 0
 

--- a/test/ms2ex/field_region_skill_test.exs
+++ b/test/ms2ex/field_region_skill_test.exs
@@ -1,0 +1,81 @@
+defmodule Ms2ex.FieldRegionSkillTest do
+  use ExUnit.Case, async: true
+
+  alias Ms2ex.Enums
+  alias Ms2ex.Managers.Field.RegionSkill
+  alias Ms2ex.Schema.Character
+  alias Ms2ex.Types
+
+  @mob_id 23_991_090
+  @oid 50_000_086
+
+  @npc_metadata %{
+    basic: %{friendly: 0, class: 1},
+    stat: %{stats: %{health: 1000, attack_speed: 100}}
+  }
+
+  test "region splash damage updates the mob without crashing" do
+    npc = Types.Npc.new(%{id: @mob_id, metadata: @npc_metadata})
+
+    mob =
+      Types.FieldNpc.new(%{
+        object_id: @oid,
+        spawn_point_id: nil,
+        npc: npc,
+        position: %Types.Coord{x: 0, y: 0, z: 0},
+        rotation: %Types.Coord{x: 0, y: 0, z: 0},
+        field: self()
+      })
+
+    state = %{npcs: %{@oid => mob}, players: %{}, topic: "test-topic", map_id: nil}
+    skill_cast = splash_cast(mob.position)
+
+    new_state = RegionSkill.apply_splash(skill_cast, state)
+
+    assert new_state.npcs[@oid].stats.health.current < mob.stats.health.current
+  end
+
+  defp splash_cast(position) do
+    %Types.SkillCast{
+      skill_id: 10_300_141,
+      skill_level: 1,
+      caster: %Character{
+        id: 1,
+        object_id: 99,
+        stats: %{
+          min_weapon_atk_cur: 100,
+          max_weapon_atk_cur: 100,
+          bonus_atk_cur: 0,
+          physical_atk_cur: 1000,
+          magical_atk_cur: 1000,
+          damage_cur: 0,
+          critical_damage_cur: 125,
+          piercing_cur: 0
+        }
+      },
+      motion_point: 0,
+      attack_point: 0,
+      position: position,
+      direction: %Types.Coord{x: 0, y: 0, z: 0},
+      rotation: %Types.Coord{x: 0, y: 0, z: 0},
+      meta: %{
+        property: %{attack_type: Enums.AttackType.get_value(:magic)},
+        levels: %{
+          "1" => %{
+            motions: [
+              %{
+                attacks: [
+                  %{
+                    damage: %{rate: 1.0, value: 0},
+                    skills: [],
+                    skills_on_damage: []
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  end
+end

--- a/test/ms2ex/packets/region_skill_test.exs
+++ b/test/ms2ex/packets/region_skill_test.exs
@@ -1,14 +1,16 @@
 defmodule Ms2ex.Packets.RegionSkillTest do
   use ExUnit.Case, async: true
+  use Mimic
 
   alias Ms2ex.Packets.RegionSkill
   alias Ms2ex.Types.Coord
   alias Ms2ex.Types.SkillCast
 
   import Ms2ex.Packets.PacketReader
+  import Ms2ex.TestHelpers
 
   setup do
-    :ets.insert(:metadata, {"table:magicpath.xml", {:ok, %{table: %{entries: %{}}}}})
+    stub_metadata(%{"table:magicpath.xml" => %{table: %{entries: %{}}}})
     :ok
   end
 

--- a/test/ms2ex/packets/region_skill_test.exs
+++ b/test/ms2ex/packets/region_skill_test.exs
@@ -10,7 +10,18 @@ defmodule Ms2ex.Packets.RegionSkillTest do
   import Ms2ex.TestHelpers
 
   setup do
-    stub_metadata(%{"table:magicpath.xml" => %{table: %{entries: %{}}}})
+    stub_metadata(%{
+      "table:magicpath.xml" => %{
+        table: %{
+          entries: %{
+            "103000111" => [
+              %{rotate?: true, fire_offset: %{x: 0.0, y: 450.0, z: 0.0}}
+            ]
+          }
+        }
+      }
+    })
+
     :ok
   end
 
@@ -54,6 +65,21 @@ defmodule Ms2ex.Packets.RegionSkillTest do
     assert_in_delta rotation_h, 0.0, 1.0e-6
     assert_in_delta rotation_v, 0.0, 1.0e-6
     assert packet == <<>>
+  end
+
+  test "rotates region points with the caster facing" do
+    packet = RegionSkill.add(321, flame_tornado_cast())
+    {_opcode, packet} = get_short(packet)
+    {_mode, packet} = get_byte(packet)
+    {_source_id, packet} = get_int(packet)
+    {_source_id2, packet} = get_int(packet)
+    {_next_tick, packet} = get_int(packet)
+    {_point_count, packet} = get_byte(packet)
+    {point, _packet} = get_coord(packet)
+
+    assert_in_delta point.x, -317.198, 0.01
+    assert_in_delta point.y, 320.198, 0.01
+    assert_in_delta point.z, 3.0, 1.0e-6
   end
 
   test "splash_skill_cast skips non-splash side effects" do
@@ -101,7 +127,7 @@ defmodule Ms2ex.Packets.RegionSkillTest do
       motion_point: 0,
       attack_point: 0,
       position: %Coord{x: 1, y: 2, z: 3},
-      rotation: %Coord{x: 0, y: 0, z: 45.0},
+      rotation: %Coord{x: 0, y: 0, z: 225.0},
       caster: %Ms2ex.Schema.Character{id: 1},
       meta: %{
         levels: %{

--- a/test/ms2ex/packets/region_skill_test.exs
+++ b/test/ms2ex/packets/region_skill_test.exs
@@ -1,0 +1,84 @@
+defmodule Ms2ex.Packets.RegionSkillTest do
+  use ExUnit.Case, async: true
+
+  alias Ms2ex.Packets.RegionSkill
+  alias Ms2ex.Types.Coord
+  alias Ms2ex.Types.SkillCast
+
+  import Ms2ex.Packets.PacketReader
+
+  setup do
+    :ets.insert(:metadata, {"table:magicpath.xml", {:ok, %{table: %{entries: %{}}}}})
+    :ok
+  end
+
+  test "keeps rotation for directional region skills" do
+    packet = RegionSkill.add(321, skill_cast(true, 45.0))
+    {_opcode, packet} = get_short(packet)
+    {mode, packet} = get_byte(packet)
+    {_source_id, packet} = get_int(packet)
+    {_source_id2, packet} = get_int(packet)
+    {_next_tick, packet} = get_int(packet)
+    {point_count, packet} = get_byte(packet)
+    {_point, packet} = get_coord(packet)
+    {_skill_id, packet} = get_int(packet)
+    {_skill_level, packet} = get_short(packet)
+    {rotation_h, packet} = get_float(packet)
+    {rotation_v, packet} = get_float(packet)
+
+    assert mode == 0
+    assert point_count == 1
+    assert_in_delta rotation_h, 45.0, 1.0e-6
+    assert_in_delta rotation_v, 0.0, 1.0e-6
+    assert packet == <<>>
+  end
+
+  test "zeros rotation for direction-less region skills" do
+    packet = RegionSkill.add(321, skill_cast(false, 45.0))
+    {_opcode, packet} = get_short(packet)
+    {mode, packet} = get_byte(packet)
+    {_source_id, packet} = get_int(packet)
+    {_source_id2, packet} = get_int(packet)
+    {_next_tick, packet} = get_int(packet)
+    {point_count, packet} = get_byte(packet)
+    {_point, packet} = get_coord(packet)
+    {_skill_id, packet} = get_int(packet)
+    {_skill_level, packet} = get_short(packet)
+    {rotation_h, packet} = get_float(packet)
+    {rotation_v, packet} = get_float(packet)
+
+    assert mode == 0
+    assert point_count == 1
+    assert_in_delta rotation_h, 0.0, 1.0e-6
+    assert_in_delta rotation_v, 0.0, 1.0e-6
+    assert packet == <<>>
+  end
+
+  defp skill_cast(use_direction, rotation_z) do
+    %SkillCast{
+      next_tick: 1234,
+      skill_id: 500_000,
+      skill_level: 1,
+      motion_point: 0,
+      attack_point: 0,
+      position: %Coord{x: 1, y: 2, z: 3},
+      rotation: %Coord{x: 0, y: 0, z: rotation_z},
+      meta: %{
+        levels: %{
+          "1" => %{
+            motions: [
+              %{
+                attacks: [
+                  %{
+                    cube_magic_path_id: 0,
+                    skills: [%{splash: %{use_direction: use_direction}}]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  end
+end

--- a/test/ms2ex/packets/region_skill_test.exs
+++ b/test/ms2ex/packets/region_skill_test.exs
@@ -56,6 +56,15 @@ defmodule Ms2ex.Packets.RegionSkillTest do
     assert packet == <<>>
   end
 
+  test "splash_skill_cast skips non-splash side effects" do
+    {splash_cast, splash} = SkillCast.splash_skill_cast(flame_tornado_cast())
+
+    assert splash_cast.skill_id == 10_300_012
+    assert splash_cast.skill_level == 10
+    assert splash.interval == 300
+    assert splash.fire_count == 5
+  end
+
   defp skill_cast(use_direction, rotation_z) do
     %SkillCast{
       next_tick: 1234,
@@ -73,7 +82,49 @@ defmodule Ms2ex.Packets.RegionSkillTest do
                 attacks: [
                   %{
                     cube_magic_path_id: 0,
-                    skills: [%{splash: %{use_direction: use_direction}}]
+                    skills: [%{has_splash: true, splash: %{use_direction: use_direction}}]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  end
+
+  defp flame_tornado_cast do
+    %SkillCast{
+      next_tick: 1234,
+      skill_id: 10_300_011,
+      skill_level: 10,
+      motion_point: 0,
+      attack_point: 0,
+      position: %Coord{x: 1, y: 2, z: 3},
+      rotation: %Coord{x: 0, y: 0, z: 45.0},
+      caster: %Ms2ex.Schema.Character{id: 1},
+      meta: %{
+        levels: %{
+          "10" => %{
+            motions: [
+              %{
+                attacks: [
+                  %{
+                    cube_magic_path_id: 103_000_111,
+                    skills: [
+                      %{id: 10_300_241, level: 1, has_splash: false, splash: %{}},
+                      %{
+                        id: 10_300_012,
+                        level: 10,
+                        has_splash: true,
+                        splash: %{
+                          interval: 300,
+                          fire_count: 5,
+                          remove_delay: 0,
+                          use_direction: true
+                        }
+                      }
+                    ]
                   }
                 ]
               }

--- a/test/ms2ex/state_skill_cost_test.exs
+++ b/test/ms2ex/state_skill_cost_test.exs
@@ -1,5 +1,6 @@
 defmodule Ms2ex.StateSkillCostTest do
   use ExUnit.Case, async: true
+  use Mimic
 
   alias Ms2ex.Managers
   alias Ms2ex.Managers.Character
@@ -166,6 +167,72 @@ defmodule Ms2ex.StateSkillCostTest do
     assert switched.stats.spirit_cur == 80
   end
 
+  test "the character manager persists regular skill spirit costs and resumes regen" do
+    Mimic.stub(Ms2ex.Storage, :get, fn _set, _id -> nil end)
+
+    character =
+      character(%{
+        id: System.unique_integer([:positive]),
+        stats: %{
+          health_max: 1000,
+          health_cur: 1000,
+          spirit_max: 100,
+          spirit_cur: 100,
+          sp_regen_cur: 5,
+          sp_regen_interval_cur: 50,
+          stamina_max: 100,
+          stamina_cur: 100,
+          stamina_regen_cur: 0,
+          hp_regen_interval_cur: 1000,
+          stamina_regen_interval_cur: 1000
+        }
+      })
+
+    {:ok, pid} = Managers.Character.start(character)
+
+    on_exit(fn ->
+      Managers.SkillCast.stop(@cast_id)
+      if Process.alive?(pid), do: GenServer.stop(pid)
+    end)
+
+    assert {:ok, casted} =
+             Managers.Character.call(character, {:cast_skill, skill_cast(character)})
+
+    assert casted.stats.spirit_cur == 90
+    assert {:ok, persisted} = Managers.Character.call(character, :lookup)
+    assert persisted.stats.spirit_cur == 90
+
+    regen_to = eventually(fn -> spirit_of(character) end, &(&1 >= 100), 2_000)
+
+    assert regen_to == 100
+  end
+
+  test "repeated spirit drains arm regen only once before the first tick" do
+    character =
+      character(%{
+        stats: %{
+          health_max: 1000,
+          health_cur: 1000,
+          spirit_max: 100,
+          spirit_cur: 100,
+          sp_regen_cur: 1,
+          sp_regen_interval_cur: 20,
+          stamina_max: 100,
+          stamina_cur: 100,
+          hp_regen_interval_cur: 1000,
+          stamina_regen_interval_cur: 1000
+        }
+      })
+
+    character = Character.Stats.decrease(character, :spirit, 10, [])
+    assert character.regen_spirit? == true
+
+    _character = Character.Stats.decrease(character, :spirit, 10, [])
+
+    refute_receive {:regen, :spirit}, 50
+    assert_receive {:regen, :spirit}, 150
+  end
+
   test "the character manager rejects a state-skill cast without resources" do
     character =
       character(%{
@@ -274,7 +341,7 @@ defmodule Ms2ex.StateSkillCostTest do
       skill_id: 15_000_220,
       skill_level: 1,
       caster: caster,
-      meta: %{levels: %{"1" => %{consume: %{stat: @drain_cost}}}}
+      meta: %{levels: %{"1" => %{consume: %{stat: @drain_cost}, skills: []}}}
     }
   end
 
@@ -293,5 +360,28 @@ defmodule Ms2ex.StateSkillCostTest do
 
   defp activate(character, skill_cast, state) do
     Map.put(character, :state_skill, %{skill_cast: skill_cast, state: state})
+  end
+
+  defp spirit_of(character) do
+    case Managers.Character.call(character, :lookup) do
+      {:ok, %{stats: %{spirit_cur: cur}}} -> cur
+      _ -> -1
+    end
+  end
+
+  defp eventually(produce, done?, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_eventually(produce, done?, deadline)
+  end
+
+  defp do_eventually(produce, done?, deadline) do
+    value = produce.()
+
+    if done?.(value) or System.monotonic_time(:millisecond) > deadline do
+      value
+    else
+      Process.sleep(25)
+      do_eventually(produce, done?, deadline)
+    end
   end
 end

--- a/test/ms2ex/stats_regen_test.exs
+++ b/test/ms2ex/stats_regen_test.exs
@@ -61,6 +61,14 @@ defmodule Ms2ex.StatsRegenTest do
     assert character.regen_stamina? == true
   end
 
+  test "spirit consumption does not defer regen" do
+    character = character(stats: [spirit_cur: 100, spirit_max: 100])
+    character = Character.Stats.decrease(character, :spirit, 40, [])
+
+    assert character.stats.spirit_cur == 60
+    refute Map.has_key?(Map.get(character, :regen_waits, %{}), :spirit)
+  end
+
   test "regen resumes once the wait expires" do
     character = character(stats: [stamina_cur: 60, stamina_max: 100])
     character = Character.Stats.decrease(character, :stamina, 10, [])
@@ -136,6 +144,19 @@ defmodule Ms2ex.StatsRegenTest do
 
     assert character.regen_waits.stamina in (before + 1_000)..(System.monotonic_time(:millisecond) +
                                                                  1_000)
+  end
+
+  test "regen interval is clamped to a minimum" do
+    character =
+      character(
+        stats: [spirit_cur: 90, spirit_max: 100, sp_regen_cur: 2, sp_regen_interval_cur: 0]
+      )
+
+    character = Character.Stats.regen(character, :spirit)
+
+    assert character.stats.spirit_cur == 92
+    assert_receive {:regen, :spirit}, 150
+    refute_receive {:regen, :spirit}, 20
   end
 
   defp character(overrides) do


### PR DESCRIPTION
## Summary
- zero `RegionSkill` horizontal rotation for direction-less skills
- fix region-splash damage tuple handling so placed skills no longer crash the field
- persist regular skill SP/stamina drains in character manager state
- align Wizard spirit regen timing with observed behavior: no SP wait, 100ms minimum tick floor
- update roadmap status and add regression coverage

## Details
This fixes roadmap issue 11 and the related spirit-regen parity bugs found while validating placed skills.

Behavior covered here:
- direction-less region skills send `RotationH = 0`
- directional region skills keep their rotation
- splash/region damage no longer crashes on NPC hits
- regular active-skill SP drains persist server-side
- SP regen resumes immediately when SP is below max
- negative interval bonuses can no longer collapse passive regen to zero-delay bursts

## Testing
- `mix test`

## Companion metadata change
This server change expects `splash.use_direction` to be projected by the ingest pipeline.
A companion commit exists in the sibling `ms2ex-file-ingest` worktree:
- `3c5da17` — `Project splash use_direction for region skills`
