### PR TITLE
Mob respawns: tick-driven spawn cycles for mob spawn points

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -4,6 +4,6 @@ DB_NAME=ms2ex_dev
 DB_HOST=localhost
 SERVER_ADDRESS=127.0.0.1
 
-# Ecto query log level in development (debug, info, warning, ... or "false"
-# to disable); defaults to error
-# ECTO_LOG_LEVEL=error
+# Ecto query log level, all envs (debug, info, warning, ... or "false" to
+# disable repo logs); defaults to warning
+# ECTO_LOG_LEVEL=warning

--- a/.env-example
+++ b/.env-example
@@ -3,3 +3,7 @@ DB_PASS=postgres
 DB_NAME=ms2ex_dev
 DB_HOST=localhost
 SERVER_ADDRESS=127.0.0.1
+
+# Ecto query log level in development (debug, info, warning, ... or "false"
+# to disable); defaults to error
+# ECTO_LOG_LEVEL=error

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,17 +26,7 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 # Configure your database
-# Ecto logs only errors in development; set ECTO_LOG_LEVEL (debug, info,
-# warning, ... or "false" to disable) to override.
-log_level =
-  case System.get_env("ECTO_LOG_LEVEL") do
-    nil -> :error
-    "false" -> false
-    level -> String.to_existing_atom(level)
-  end
-
 config :ms2ex, Ms2ex.Repo,
-  log: log_level,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -26,7 +26,17 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 # Configure your database
+# Ecto logs only errors in development; set ECTO_LOG_LEVEL (debug, info,
+# warning, ... or "false" to disable) to override.
+log_level =
+  case System.get_env("ECTO_LOG_LEVEL") do
+    nil -> :error
+    "false" -> false
+    level -> String.to_existing_atom(level)
+  end
+
 config :ms2ex, Ms2ex.Repo,
+  log: log_level,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,7 +8,9 @@ source!([
   System.get_env()
 ])
 
+# Ecto query log level (warning by default; "false" disables repo logs)
 config :ms2ex, Ms2ex.Repo,
+  log: env!("ECTO_LOG_LEVEL", :existing_atom, :warning),
   username: env!("DB_USER"),
   password: env!("DB_PASS"),
   database: env!("DB_NAME"),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,6 +49,22 @@ still skipped:
 Flat skill damage (`damage.value`) is applied from metadata, and DoT damage
 scales with the caster's attack via the shared formula.
 
+### 13. Mob spawn cycles — [Partial]
+
+Mob spawn points now run spawn cycles from the field tick loop: the initial
+population spawns on the first due cycle, mob deaths schedule the next cycle
+(full wipe → `regen_check_time` cooldown, partial kill → 2× cooldown while no
+cycle is pending), and every due cycle refills the population to full.
+Zero-cooldown spawns never refill. What is still missing:
+
+- pet spawn rolls for mob spawns (`pet_population` / `pet_spawn_rate`) — the
+  metadata is not projected by the ingest yet
+- navmesh-valid spawn position picking — mobs currently randomize ±250 around
+  the spawn point instead of snapping to map spawn volumes
+- friendly NPC spawn points are still spawned eagerly at field load; their
+  trigger-driven creation and `regen_check_time` top-up checks are not
+  implemented
+
 ---
 
 ## P2 — Combat systems depth
@@ -114,6 +130,9 @@ damage accumulation + `DpsStat` flow (see `docs/internal/party-dps-meter.md`).
 
 ## Recently completed
 
+- Mob respawns: mob spawn points refill their population through tick-driven
+  spawn cycles, scheduled by mob deaths (wipe → cooldown, partial kill → 2×
+  cooldown, zero cooldown → never)
 - RegionSkill rotation: direction-less region skills now zero horizontal
   rotation while directional ones keep it; region-splash damage no longer
   crashes on hit, and regular-skill spirit drains now persist so Wizard SP

--- a/lib/ms2ex/managers/field/npc.ex
+++ b/lib/ms2ex/managers/field/npc.ex
@@ -12,6 +12,8 @@ defmodule Ms2ex.Managers.Field.Npc do
   # client dropping controls sent while it asynchronously loads the entity
   @idle_control_ms 30
   @corpse_broadcast_ms 1000
+  @spawn_rate_ms 1000
+  @force_spawn_multiplier 2
 
   def load_npc_spawns(state) do
     state.map_id
@@ -38,21 +40,59 @@ defmodule Ms2ex.Managers.Field.Npc do
     {spawn_point_id, state} = Managers.Field.next_local_id(state)
     npc_spawn = Map.put(npc_spawn, :id, spawn_point_id)
 
-    state =
-      if npc_spawn[:regen_check_time] > 0 || npc_spawn[:population] > 0 do
-        put_in(state, [:npc_spawns, spawn_point_id], npc_spawn)
-      else
-        state
-      end
+    if mob_spawn?(npc_spawn) do
+      # mob spawn points fill their population through the tick-driven spawn
+      # cycle; the first cycle is due as soon as the spawn is loaded
+      npc_spawn =
+        npc_spawn
+        |> Map.put(:spawned_mobs, [])
+        |> Map.put(:spawn_tick, Ms2ex.sync_ticks())
 
-    Enum.each(npc_ids, fn npc_id ->
-      send(self(), {:add_npc, npc_id, npc_spawn})
-    end)
+      put_in(state, [:npc_spawns, spawn_point_id], npc_spawn)
+    else
+      state =
+        if npc_spawn[:regen_check_time] > 0 || npc_spawn[:population] > 0 do
+          put_in(state, [:npc_spawns, spawn_point_id], npc_spawn)
+        else
+          state
+        end
 
+      Enum.each(npc_ids, fn npc_id ->
+        send(self(), {:add_npc, npc_id, npc_spawn})
+      end)
+
+      state
+    end
+  end
+
+  # mob spawn documents carry a flat npc_ids list; friendly spawn points carry
+  # npc_list entries instead
+  defp mob_spawn?(npc_spawn), do: Map.has_key?(npc_spawn, :npc_ids)
+
+  def load_npc(state, %Types.Npc{} = npc, npc_spawn) do
+    {_field_npc, state} = spawn_npc(state, npc, npc_spawn)
     state
   end
 
-  def load_npc(state, %Types.Npc{} = npc, npc_spawn) do
+  def load_npc(state, npc_id, npc_spawn) do
+    {_field_npc, state} = spawn_npc(state, npc_id, npc_spawn)
+    state
+  end
+
+  # Creates the field entity for an npc and announces it to clients. Returns
+  # {nil, state} when the npc id has no metadata (nothing is spawned).
+  def spawn_npc(state, npc_id, npc_spawn) when is_integer(npc_id) do
+    case Storage.Npcs.get_meta(npc_id) do
+      %{} = metadata ->
+        npc = Types.Npc.new(%{id: npc_id, metadata: metadata})
+        spawn_npc(state, npc, npc_spawn)
+
+      _ ->
+        {nil, state}
+    end
+  end
+
+  def spawn_npc(state, %Types.Npc{} = npc, npc_spawn) do
     {object_id, state} = Managers.Field.next_local_id(state)
 
     field_npc =
@@ -68,15 +108,40 @@ defmodule Ms2ex.Managers.Field.Npc do
     Context.Field.broadcast(state.topic, Packets.FieldAddNpc.add_npc(field_npc))
     Context.Field.broadcast(state.topic, Packets.ProxyGameObj.load_npc(field_npc))
 
-    put_in(state, [:npcs, object_id], field_npc)
+    {field_npc, put_in(state, [:npcs, object_id], field_npc)}
   end
 
-  def load_npc(state, npc_id, npc_spawn) do
-    with %{} = metadata <- Storage.Npcs.get_meta(npc_id),
-         npc <- Types.Npc.new(%{id: npc_id, metadata: metadata}) do
-      load_npc(state, npc, npc_spawn)
-    else
-      _ -> state
+  # A mob death frees its population slot and schedules the next spawn cycle:
+  # a spawn wiped down to zero mobs starts its cooldown, while a partial kill
+  # (with no cycle pending) respawns at twice the cooldown. A zero cooldown
+  # means the spawn point never refills.
+  def despawn(state, %FieldNpc{} = field_npc) do
+    case get_in(state, [:npc_spawns, field_npc.spawn_point_id]) do
+      %{} = spawn when is_map_key(spawn, :npc_ids) ->
+        spawned = List.delete(spawn.spawned_mobs, field_npc.object_id)
+        spawn = %{spawn | spawned_mobs: spawned}
+        put_in(state, [:npc_spawns, spawn.id], schedule_spawn(spawn))
+
+      _ ->
+        state
+    end
+  end
+
+  defp schedule_spawn(%{regen_check_time: cooldown} = spawn) when cooldown <= 0, do: spawn
+
+  defp schedule_spawn(spawn) do
+    now = Ms2ex.sync_ticks()
+    cooldown_ms = spawn.regen_check_time * @spawn_rate_ms
+
+    cond do
+      spawn.spawned_mobs == [] ->
+        %{spawn | spawn_tick: min(spawn.spawn_tick, now + cooldown_ms)}
+
+      spawn.spawn_tick == :infinity ->
+        %{spawn | spawn_tick: now + cooldown_ms * @force_spawn_multiplier}
+
+      true ->
+        spawn
     end
   end
 
@@ -153,6 +218,42 @@ defmodule Ms2ex.Managers.Field.Npc do
     end
 
     %{state | npcs: Map.new(npcs)}
+    |> tick_mob_spawns()
+  end
+
+  # Runs due spawn cycles for mob spawn points: every cycle fills the
+  # population back up to full, choosing a random npc id per slot. Timed on
+  # sync_ticks so scheduling never depends on the raw clock base.
+  defp tick_mob_spawns(state) do
+    now = Ms2ex.sync_ticks()
+
+    state
+    |> Map.get(:npc_spawns, %{})
+    |> Enum.reduce(state, fn {spawn_point_id, spawn}, state ->
+      if mob_spawn?(spawn) and now >= spawn.spawn_tick do
+        spawn = %{spawn | spawn_tick: :infinity}
+        {spawn, state} = spawn_missing_mobs(spawn, state)
+        put_in(state, [:npc_spawns, spawn_point_id], spawn)
+      else
+        state
+      end
+    end)
+  end
+
+  # TODO: pet spawn roll (pet_spawn_rate) — pet metadata is not projected yet
+  defp spawn_missing_mobs(spawn, state) do
+    missing = spawn.population - length(spawn.spawned_mobs)
+
+    Enum.reduce(1..max(missing, 0), {spawn, state}, fn _i, {spawn, state} ->
+      case spawn_npc(state, Enum.random(spawn.npc_ids), spawn) do
+        {%FieldNpc{} = field_npc, state} ->
+          spawned = spawn.spawned_mobs ++ [field_npc.object_id]
+          {%{spawn | spawned_mobs: spawned}, state}
+
+        {nil, state} ->
+          {spawn, state}
+      end
+    end)
   end
 
   defp tag_attackers(field_npc, attacker) do
@@ -171,11 +272,11 @@ defmodule Ms2ex.Managers.Field.Npc do
 
     Context.Mobs.drop_hit_rewards(field_npc, state.map_id)
 
-    field_npc =
+    {field_npc, state} =
       if hp == 0 do
-        announce_death(%{field_npc | stats: stats}, state.topic, state.map_id)
+        announce_death(%{field_npc | stats: stats}, state)
       else
-        %{field_npc | stats: stats}
+        {%{field_npc | stats: stats}, state}
       end
 
     {:ok, field_npc, put_in(state, [:npcs, object_id], field_npc)}
@@ -185,7 +286,7 @@ defmodule Ms2ex.Managers.Field.Npc do
   # animation on its own before the corpse is removed. The hp=0 sync must
   # reach the client BEFORE the dead control entry, otherwise it ignores
   # the state change.
-  defp announce_death(field_npc, topic, map_id) do
+  defp announce_death(field_npc, state) do
     corpse? = get_in(field_npc.npc.metadata, [:corpse, :hit_able]) || false
 
     field_npc =
@@ -198,8 +299,8 @@ defmodule Ms2ex.Managers.Field.Npc do
           last_control_at: System.monotonic_time(:millisecond)
       }
 
-    Context.Field.broadcast(topic, Packets.Stats.update_mob_stat(field_npc, :health))
-    Context.Field.broadcast(topic, Packets.ControlNpc.dead(field_npc))
+    Context.Field.broadcast(state.topic, Packets.Stats.update_mob_stat(field_npc, :health))
+    Context.Field.broadcast(state.topic, Packets.ControlNpc.dead(field_npc))
 
     # corpse-hittable bodies stay around for their full window so players can
     # keep striking them; everyone else despawns once the animation settles
@@ -212,12 +313,14 @@ defmodule Ms2ex.Managers.Field.Npc do
 
     Process.send_after(self(), {:remove_npc, field_npc}, :timer.seconds(corpse_time))
 
-    Context.Mobs.drop_rewards(field_npc, map_id)
+    Context.Mobs.drop_rewards(field_npc, state.map_id)
     Context.Mobs.reward_exp(field_npc)
+
+    state = despawn(state, field_npc)
 
     # TODO: Player Condition update (quest, achievements...)
 
-    field_npc
+    {field_npc, state}
   end
 
   defp tick_npc(now, object_id, npc, {live, corpses}) do

--- a/test/ms2ex/mob_respawn_test.exs
+++ b/test/ms2ex/mob_respawn_test.exs
@@ -1,0 +1,161 @@
+defmodule Ms2ex.MobRespawnTest do
+  use Ms2ex.DataCase, async: true
+
+  alias Ms2ex.Managers.Field
+  alias Ms2ex.Managers.Field.Npc
+
+  @mob_id 23_991_090
+  @attacker %Ms2ex.Schema.Character{id: 1, name: "Testy"}
+  @cooldown_s 10
+  @lethal_dmg 2000
+
+  # minimal metadata fixture so the test runs without the game-data store
+  @npc_metadata %{
+    basic: %{friendly: 0, class: 0, level: 10},
+    stat: %{stats: %{health: 1000, attack_speed: 100}}
+  }
+
+  setup do
+    stub_metadata(%{"npc:#{@mob_id}" => @npc_metadata})
+    :ok
+  end
+
+  defp base_state do
+    %{
+      npcs: %{},
+      npc_spawns: %{},
+      players: %{},
+      topic: "test-topic",
+      map_id: nil,
+      local_id_counter: 50_000_000
+    }
+  end
+
+  defp spawn_doc(cooldown \\ @cooldown_s) do
+    %{
+      npc_ids: [@mob_id, @mob_id],
+      regen_check_time: cooldown,
+      population: 2,
+      position: %{x: 0.0, y: 0.0, z: 0.0},
+      rotation: %{x: 0.0, y: 0.0, z: 0.0}
+    }
+  end
+
+  defp load_spawn(state, doc) do
+    state = Npc.load_spawn(state, doc, doc.npc_ids)
+    tick(state)
+  end
+
+  defp kill(state, object_id) do
+    {:reply, {:ok, _mob}, state} =
+      Field.handle_call({:inflict_dmg, @attacker, %{dmg: @lethal_dmg}, object_id}, nil, state)
+
+    state
+  end
+
+  defp kill_all(state) do
+    state.npcs
+    |> Map.keys()
+    |> Enum.reduce(state, fn oid, state -> kill(state, oid) end)
+  end
+
+  defp tick(state) do
+    {:noreply, state} = Field.handle_info(:tick_npcs, state)
+    state
+  end
+
+  defp alive(state), do: Enum.count(state.npcs, fn {_oid, npc} -> not npc.dead? end)
+
+  defp spawn_state(state), do: state.npc_spawns |> Map.values() |> hd()
+
+  test "the first cycle fills the population" do
+    state = load_spawn(base_state(), spawn_doc())
+    spawn = spawn_state(state)
+
+    assert map_size(state.npcs) == 2
+    assert length(spawn.spawned_mobs) == 2
+    assert Enum.all?(state.npcs, fn {_oid, npc} -> npc.spawn_point_id == spawn.id end)
+    assert spawn.spawn_tick == :infinity
+  end
+
+  test "wiping the spawn schedules one respawn after the cooldown" do
+    state = load_spawn(base_state(), spawn_doc())
+    spawn_id = spawn_state(state).id
+
+    state = kill_all(state)
+    spawn = spawn_state(state)
+
+    assert spawn.spawned_mobs == []
+    assert is_integer(spawn.spawn_tick)
+    assert_in_delta(spawn.spawn_tick - Ms2ex.sync_ticks(), @cooldown_s * 1000, 100)
+
+    # cooldown has not elapsed yet: nothing respawns
+    state = tick(state)
+    assert alive(state) == 0
+
+    # once the cooldown elapses, the population refills
+    now = Ms2ex.sync_ticks()
+    state = put_in(state, [:npc_spawns, spawn_id], %{spawn | spawn_tick: now - 1})
+    state = tick(state)
+
+    assert alive(state) == 2
+    assert length(spawn_state(state).spawned_mobs) == 2
+    assert spawn_state(state).spawn_tick == :infinity
+  end
+
+  test "a partial kill schedules the respawn at twice the cooldown" do
+    state = load_spawn(base_state(), spawn_doc())
+    [oid | _rest] = spawn_state(state).spawned_mobs
+
+    state = kill(state, oid)
+    spawn = spawn_state(state)
+
+    assert length(spawn.spawned_mobs) == 1
+
+    assert_in_delta(spawn.spawn_tick - Ms2ex.sync_ticks(), @cooldown_s * 2000, 100)
+  end
+
+  test "an earlier scheduled respawn wins over a later wipe" do
+    state = load_spawn(base_state(), spawn_doc())
+    [oid1, oid2] = spawn_state(state).spawned_mobs
+
+    # first death schedules at 2x cooldown, second death (full wipe) should
+    # pull the cycle in to the plain cooldown
+    state = kill(state, oid1)
+    state = kill(state, oid2)
+
+    assert_in_delta(
+      spawn_state(state).spawn_tick - Ms2ex.sync_ticks(),
+      @cooldown_s * 1000,
+      100
+    )
+  end
+
+  test "a zero cooldown spawn never respawns" do
+    state = load_spawn(base_state(), spawn_doc(0))
+    state = kill_all(state)
+    spawn = spawn_state(state)
+
+    assert spawn.spawned_mobs == []
+    assert spawn.spawn_tick == :infinity
+
+    state = tick(state)
+    assert alive(state) == 0
+  end
+
+  test "friendly spawn points load eagerly and never run spawn cycles" do
+    doc = %{
+      npc_list: [%{npc_id: @mob_id, count: 1}],
+      regen_check_time: 0,
+      population: 1,
+      position: %{x: 0.0, y: 0.0, z: 0.0},
+      rotation: %{x: 0.0, y: 0.0, z: 0.0}
+    }
+
+    state = Npc.load_spawn(base_state(), doc, [doc.npc_list |> hd() |> Map.get(:npc_id)])
+    spawn = spawn_state(state)
+
+    refute Map.has_key?(spawn, :spawned_mobs)
+    refute Map.has_key?(spawn, :spawn_tick)
+  end
+end


### PR DESCRIPTION
## Summary

Mob spawn points now run spawn cycles from the field tick loop instead of spawning their population once at field load:

- **Initial population** spawns on the first due cycle (cycle is due as soon as the spawn point loads)
- **Mob deaths schedule the next cycle**: a full wipe starts the `regen_check_time` cooldown; a partial kill (with no cycle pending) respawns at **2× the cooldown**; an earlier scheduled cycle always wins
- **Zero cooldown** → the spawn point never refills
- Each due cycle refills the population to full, drawing a random npc id per slot
- Friendly spawn points (`npc_list` docs) keep their eager load; only mob spawn docs (`npc_ids`) participate in cycles

Cycle timing uses `Ms2ex.sync_ticks()` so scheduling never depends on the raw monotonic clock base (which can be negative under multi-time-warp — see the comment in `lib/ms2ex.ex`).

## Out of scope / follow-ups

- Pet spawn rolls (`pet_population` / `pet_spawn_rate`) — pet metadata is not projected by the ingest yet
- Navmesh-valid spawn position picking (mobs randomize ±250 around the spawn point)
- Trigger-driven friendly spawn-point creation + `regen_check_time` top-up checks

See `docs/ROADMAP.md` item 13 for the remaining gaps.