### PR TITLE
Equipment state extraction

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -248,7 +248,6 @@ combat-heavy characters from accumulating document copies.
 - Manager state carries no item metadata: the cached equip list and field
   drops hold plain item rows, and stat rebuilds, gear score, and pickup
   re-read the storage cache (ETS) at point of use
-
 - Quest command surface: forfeit enforcement (non-forfeitable quests refuse
   abandon), the client expiration sweep (drops persisted rows and acknowledges
   with the expired-quest packet), and go-to-npc travel to a started quest's

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -207,7 +207,7 @@ long-term model is full ownership in memory, genre-standard for MMO servers:
 - when this lands, equips fold into it (they are items with
   `location: :equipment`) rather than keeping a separate equip owner
 
-### 18. Metadata-free manager state — [Open]
+### 18. Metadata-free manager state — [Partial]
 
 Metadata documents are virtual fields on items and get embedded wherever
 structs are cached in GenServer state, so manager memory grows with document

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,6 +83,8 @@ Applied today: `status.values` / `status.rates` stat modifiers, the
 - condition and immune-category checks are not evaluated
 - recovery is skipped on mob-owned buffs; empty effects are applied as no-op
   buffs
+- item-granted buffs (equip effects with buff payloads) are not applied or
+  removed on unequip
 
 ### 6. SkillDamage Tile damage mode — [Partial]
 
@@ -92,6 +94,16 @@ The Tile (0x6) mode, tied to tile skills, is still unimplemented.
 ---
 
 ## P3 — Client parity & serialization
+
+### 17. Item systems: gem sockets, pet items, gacha — [Open]
+
+The item packet writes the reference defaults for three systems ms2ex does
+not implement, so every item currently serializes identically to an item
+without those features: the gacha dismantle id (always 0), the pet info
+block (never written), and gemstone sockets (empty socket block only;
+socket unlocking and gemstones are unimplemented). Implementing any of
+these needs the feature system plus, for pets, ingest projection of pet
+metadata.
 
 ### 7. Join-flow packet audit — [Open]
 
@@ -181,7 +193,9 @@ long-term model is full ownership in memory, genre-standard for MMO servers:
   on logout
 - every call site routed through it: pickup/drop, consume, move/split/merge,
   equip changes, rewards, and shops/trades/storage/mail as those features
-  arrive
+  arrive; slot allocation (`find_first_available_slot`) becomes a scan over
+  the owned item list bounded by the tab's persisted slot count instead of a
+  per-write query against hardcoded slot ranges
 - the completion-time `Repo.transaction` atomicity (quest row + turn-in
   consumption + rewards) becomes in-process ordering inside the manager, since
   a DB transaction cannot span its memory
@@ -193,26 +207,47 @@ long-term model is full ownership in memory, genre-standard for MMO servers:
 - when this lands, equips fold into it (they are items with
   `location: :equipment`) rather than keeping a separate equip owner
 
-### 16. Equipment state extraction — [Open]
+### 18. Metadata-free manager state — [Open]
 
-`character.equips` is kept fresh in the character manager, but only through
-handler-level orchestration: equip/unequip handlers query the inventory,
-mutate via `Context.Equips`, re-query the equip list, re-apply stats, push
-the whole struct back into the manager, and broadcast packets — while
-`character_info` and `item_stats` re-query equips independently.
+Metadata documents are virtual fields on items and get embedded wherever
+structs are cached in GenServer state, so manager memory grows with document
+sizes instead of entity counts. The item side is lean now: the character
+manager's cached equip list and the field manager's dropped items hold rows
+without metadata and re-read the storage cache at point of use (stat
+rebuilds, pickup). Still holding documents in state:
 
-Extract the domain into a `Managers.Character.Equips` submodule (like
-`.Experience` / `.Stats`): the character process owns the transition and
-returns fresh state, and handlers issue one call instead of orchestrating
-half a dozen context calls. Deliberately a module split, **not** a separate
-GenServer: equips are read constantly by field serialization of other
-players, they are items (see item 15), and a standalone equip process would
-fragment item state across two owners with the sync boundary exactly at the
-hot equip↔inventory transitions.
+- `Types.Npc` keeps npc metadata per field NPC (mob AI, spawns, drop rolls
+  and corpses read it)
+- the quest manager caches the quest metadata document on every active quest
+- `Types.Buff` keeps the full effect document on every active buff
+
+Replacing those with fetch-from-cache-at-use keeps long-lived fields and
+combat-heavy characters from accumulating document copies.
 
 ---
 
 ## Recently completed
+
+- Equipment state extraction: equip transitions moved into the character
+  process (`Managers.Character.Equips`, like `.Experience` / `.Stats`) — one
+  manager call runs the whole equip/unequip and returns fresh state, and
+  character info reads the manager's equip list instead of re-querying.
+  Deliberately a module split, **not** a separate GenServer: equips are read
+  constantly by field serialization of other players and are items (see
+  item 15), so a standalone equip process would fragment item state across
+  two owners
+- Equip parity & slot allocation: slot scans are bounded by the tab's
+  persisted slot count (base + expansions) instead of a hardcoded range, and
+  free-slot counting feeds the multi-slot equip pre-check; the equip
+  transition now validates the request (target slot must be the item's
+  primary slot, level/expiry/job limits, localized error boxes), resolves
+  conflicts and unequips in the reference order (vacated slot preferred,
+  full-inventory refusal), and discards cosmetic looks (hair/ears/face/face
+  decal) on unequip. Pickups no longer lose the drop when the inventory is
+  full — the field item stays
+- Manager state carries no item metadata: the cached equip list and field
+  drops hold plain item rows, and stat rebuilds, gear score, and pickup
+  re-read the storage cache (ETS) at point of use
 
 - Quest command surface: forfeit enforcement (non-forfeitable quests refuse
   abandon), the client expiration sweep (drops persisted rows and acknowledges

--- a/lib/ms2ex/context/equips.ex
+++ b/lib/ms2ex/context/equips.ex
@@ -1,9 +1,12 @@
 defmodule Ms2ex.Context.Equips do
   @moduledoc """
-  Context module for equipment-related operations.
+  Context module for equipment persistence.
 
-  This module provides functions for listing, equipping, and unequipping items,
-  as well as validating equipment slots.
+  Provides the item-level operations behind equip transitions: reading a
+  character's equipped items, moving items between inventory and equipment,
+  and validating equipment slots. The equip transition itself (conflicting
+  items, state refresh, notifications) is owned by the character process,
+  see `Ms2ex.Managers.Character.Equips`.
   """
 
   alias Ms2ex.Context
@@ -14,10 +17,16 @@ defmodule Ms2ex.Context.Equips do
   import Ecto.Query, except: [update: 2]
   import Context.Inventory, only: [update_item: 2, find_first_available_slot: 2]
 
+  # looks worn in these slots are discarded when unequipped rather than
+  # returned to the inventory
+  @discard_on_unequip_slots [:HR, :ER, :FA, :FD]
+
   @doc """
   Lists all equipped items for a given character.
 
-  Returns a list of items with their metadata loaded.
+  The rows are returned without their metadata documents; callers fetch
+  metadata from the storage cache only when they need it, so cached copies
+  of the list stay lean.
 
   ## Examples
 
@@ -29,71 +38,17 @@ defmodule Ms2ex.Context.Equips do
     Schema.Item
     |> where([i], i.character_id == ^char_id and i.location == ^:equipment)
     |> Repo.all()
-    |> Enum.map(&Context.Items.load_metadata(&1))
   end
 
   @doc """
-  Finds items that are equipped in specific slots.
-
-  Handles special cases for pants (checking for suits) and off-hand weapons.
-
-  ## Parameters
-
-    * `equips` - List of equipped items to search through
-    * `slots` - List of slot types to check
-    * `inventory_tab` - The inventory tab to filter by
-    * `requested_slot` - Optional specific slot requested (used for off-hand weapons)
+  Equips an item into the requested equipment slot.
 
   ## Examples
 
-      iex> find_equipped_in_slots(equips, [:HD], :outfit)
-      [%Schema.Item{equip_slot: :HD, ...}]
-  """
-  @spec find_equipped_in_slots(
-          [Schema.Item.t()],
-          [atom()],
-          atom(),
-          atom() | nil
-        ) :: [Schema.Item.t()]
-  def find_equipped_in_slots(equips, slots, inventory_tab, requested_slot \\ nil)
-
-  # When we are equipping pants, we need to check if we have a suit (CL) equipped
-  def find_equipped_in_slots(equips, [:PA], inventory_tab, _requested_slot) do
-    suit =
-      Enum.find(equips, &(&1.metadata.slots == [:CL, :PA] and &1.inventory_tab == inventory_tab))
-
-    slots =
-      if suit do
-        [:CL, :PA]
-      else
-        [:PA]
-      end
-
-    Enum.filter(equips, &(&1.equip_slot in slots and &1.inventory_tab == inventory_tab))
-  end
-
-  # When we are equipping off-hand weapons, we need to check against the slot requested by the client
-  def find_equipped_in_slots(equips, slots, inventory_tab, requested_slot) when slots == [:OH] do
-    Enum.filter(equips, &(&1.equip_slot == requested_slot and &1.inventory_tab == inventory_tab))
-  end
-
-  def find_equipped_in_slots(equips, slots, inventory_tab, _requested_slot) do
-    Enum.filter(equips, &(&1.equip_slot in slots and &1.inventory_tab == inventory_tab))
-  end
-
-  @doc """
-  Equips an item using its first available slot.
-
-  ## Examples
-
-      iex> equip(item)
+      iex> equip(item, :RH)
       {:ok, %Schema.Item{location: :equipment, ...}}
   """
-  @spec equip(Schema.Item.t()) :: {:ok, Schema.Item.t()} | {:error, any()}
-  def equip(%Schema.Item{metadata: meta} = item) do
-    equip(item, List.first(meta.slot_names))
-  end
-
+  @spec equip(Schema.Item.t(), atom()) :: {:ok, Schema.Item.t()} | {:error, any()}
   def equip(%Schema.Item{location: :inventory} = item, equip_slot) do
     item
     |> Schema.Item.bind_if_needed(:equip)
@@ -101,30 +56,64 @@ defmodule Ms2ex.Context.Equips do
   end
 
   @doc """
-  Unequips an item, moving it back to inventory.
+  Unequips an item, moving it back to the inventory.
 
-  Finds an available inventory slot and updates the item location.
+  Prefers `preferred_slot` when it is free, else falls back to the first
+  available slot in the tab. Items in cosmetic slots (hair, ears, face,
+  face decal) are discarded instead: those looks cannot be worn again once
+  removed.
 
   ## Examples
 
       iex> unequip(item)
       {:ok, %Schema.Item{location: :inventory, ...}}
 
-      iex> unequip(already_unequipped_item)
-      {:error, :item_not_equipped}
-  """
-  @spec unequip(Schema.Item.t()) :: {:ok, Schema.Item.t()} | {:error, atom()}
-  def unequip(%Schema.Item{} = item) do
-    with slot <- find_first_available_slot(item.character_id, item.inventory_tab),
-         {:ok, item} <-
-           update_item(item, %{equip_slot: :NONE, inventory_slot: slot, location: :inventory}) do
-      {:ok, item}
-    else
-      %Schema.Item{location: :inventory} ->
-        {:error, :item_not_equipped}
+      iex> unequip(hair_item)
+      {:discard, %Schema.Item{}}
 
-      nil ->
-        {:error, :item_not_found}
+      iex> unequip(item)
+      {:error, :full_inventory}
+  """
+  @spec unequip(Schema.Item.t(), integer() | nil) ::
+          {:ok, Schema.Item.t()} | {:discard, Schema.Item.t()} | {:error, atom()}
+  def unequip(%Schema.Item{} = item, preferred_slot \\ nil) do
+    if item.equip_slot in @discard_on_unequip_slots do
+      discard(item)
+    else
+      move_to_inventory(item, preferred_slot)
+    end
+  end
+
+  defp discard(%Schema.Item{} = item) do
+    case Context.Inventory.delete(item) do
+      {:delete, item} -> {:discard, item}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp move_to_inventory(item, preferred_slot) do
+    case available_slot(item, preferred_slot) do
+      {:ok, slot} ->
+        update_item(item, %{equip_slot: :NONE, inventory_slot: slot, location: :inventory})
+
+      error ->
+        error
+    end
+  end
+
+  # prefers the given slot while it is still free, else falls back to the
+  # first open slot in the tab
+  defp available_slot(item, preferred_slot) when is_integer(preferred_slot) do
+    case Context.Inventory.item_in_slot(item.character_id, item.inventory_tab, preferred_slot) do
+      nil -> {:ok, preferred_slot}
+      _item -> available_slot(item, nil)
+    end
+  end
+
+  defp available_slot(item, _preferred_slot) do
+    case find_first_available_slot(item.character_id, item.inventory_tab) do
+      slot when is_integer(slot) -> {:ok, slot}
+      error -> error
     end
   end
 

--- a/lib/ms2ex/context/inventory.ex
+++ b/lib/ms2ex/context/inventory.ex
@@ -390,23 +390,61 @@ defmodule Ms2ex.Context.Inventory do
   @doc """
   Finds the first available inventory slot in a given tab.
 
+  The scan is bounded by the tab's persisted slot count (base size plus any
+  expansions); when every slot is taken it returns `{:error, :full_inventory}`.
+
   ## Examples
 
       iex> find_first_available_slot(1, :outfit)
       5
+
+      iex> find_first_available_slot(1, :gear)
+      {:error, :full_inventory}
   """
   @spec find_first_available_slot(integer(), atom()) :: integer() | {:error, :full_inventory}
   def find_first_available_slot(character_id, inventory_tab) do
-    slots =
-      Schema.Item
-      |> select([i], i.inventory_slot)
-      |> where([i], i.character_id == ^character_id)
-      |> where([i], i.location == ^:inventory and i.inventory_tab == ^inventory_tab)
-      |> order_by(asc: :inventory_slot)
-      |> Repo.all()
+    last_slot = tab_size(character_id, inventory_tab) - 1
 
-    # TODO read inventory slots from DB
-    Enum.find(0..149, fn slot -> not Enum.member?(slots, slot) end) || {:error, :full_inventory}
+    occupied = occupied_slots(character_id, inventory_tab)
+
+    Enum.find(0..last_slot, fn slot -> not Enum.member?(occupied, slot) end) ||
+      {:error, :full_inventory}
+  end
+
+  @doc """
+  Counts the free inventory slots in a given tab.
+
+  ## Examples
+
+      iex> free_slot_count(1, :gear)
+  """
+  @spec free_slot_count(integer(), atom()) :: non_neg_integer()
+  def free_slot_count(character_id, inventory_tab) do
+    size = tab_size(character_id, inventory_tab)
+    occupied = Enum.count(occupied_slots(character_id, inventory_tab), &(&1 >= 0 and &1 < size))
+
+    max(size - occupied, 0)
+  end
+
+  defp occupied_slots(character_id, inventory_tab) do
+    Schema.Item
+    |> select([i], i.inventory_slot)
+    |> where([i], i.character_id == ^character_id)
+    |> where([i], i.location == ^:inventory and i.inventory_tab == ^inventory_tab)
+    |> order_by(asc: :inventory_slot)
+    |> Repo.all()
+  end
+
+  # the tab row carries the character's current slot count for the tab
+  # (base size plus expansions purchased in game)
+  defp tab_size(character_id, inventory_tab) do
+    case Repo.get_by(Schema.InventoryTab, character_id: character_id, tab: inventory_tab) do
+      %Schema.InventoryTab{slots: slots} when is_integer(slots) and slots > 0 ->
+        slots
+
+      _ ->
+        Map.get(Schema.InventoryTab.default_slots(), inventory_tab, 48)
+    end
   end
 
   @doc """

--- a/lib/ms2ex/context/item_stats.ex
+++ b/lib/ms2ex/context/item_stats.ex
@@ -210,7 +210,11 @@ defmodule Ms2ex.Context.ItemStats do
         _ -> Context.Equips.list(character)
       end
 
-    Enum.filter(equips, &(&1.inventory_tab == :gear))
+    # metadata is not cached on the character; it is read from the storage
+    # cache while the stats are rebuilt
+    equips
+    |> Enum.filter(&(&1.inventory_tab == :gear))
+    |> Enum.map(&Context.Items.load_metadata(&1))
   end
 
   defp calculate_gear_score(equips) do

--- a/lib/ms2ex/handlers/game/equip_item.ex
+++ b/lib/ms2ex/handlers/game/equip_item.ex
@@ -1,10 +1,7 @@
 defmodule Ms2ex.GameHandlers.EquipItem do
   alias Ms2ex.Managers
-  alias Ms2ex.Context
-  alias Ms2ex.Packets
 
-  import Packets.PacketReader
-  import Ms2ex.Net.SenderSession, only: [push: 2]
+  import Ms2ex.Packets.PacketReader
 
   def handle(packet, session) do
     {mode, packet} = get_byte(packet)
@@ -16,76 +13,18 @@ defmodule Ms2ex.GameHandlers.EquipItem do
     {id, packet} = get_long(packet)
     {slot_name, _packet} = get_ustring(packet)
 
-    with true <- Context.Equips.valid_slot?(slot_name),
-         {:ok, character} <- Managers.Character.call(session.character_id, :lookup),
-         %{location: :inventory} = item <-
-           Context.Inventory.get_by(character_id: character.id, id: id) do
-      item = Context.Items.load_metadata(item)
-      equip_slot = String.to_existing_atom(slot_name)
-      equip_item(character, equip_slot, item, session)
-    end
+    Managers.Character.call(session.character_id, {:equip_item, id, slot_name})
+    session
   end
 
   # Unequip
   defp handle_mode(0x1, packet, session) do
     {id, _packet} = get_long(packet)
 
-    with {:ok, character} <- Managers.Character.call(session.character_id, :lookup),
-         %{location: :equipment} = item <-
-           Context.Inventory.get_by(character_id: character.id, id: id) do
-      unequip_item(character, item, session)
-    end
+    Managers.Character.call(session.character_id, {:unequip_item, id})
+    session
   end
 
   # Swap
   defp handle_mode(0x2, _packet, session), do: session
-
-  defp equip_item(character, equip_slot, %{location: :inventory} = item, session) do
-    equips = Context.Equips.list(character)
-
-    # find currently equipped item in the same slot and unequip it
-    equipped_items =
-      Context.Equips.find_equipped_in_slots(
-        equips,
-        item.metadata.slots,
-        item.inventory_tab,
-        equip_slot
-      )
-
-    Enum.each(equipped_items, fn item ->
-      unequip_item(character, item, session)
-    end)
-
-    with {:ok, item} <- Context.Equips.equip(item, equip_slot) do
-      equip_packet = Packets.EquipItem.bytes(character, item)
-      Context.Field.broadcast(character, equip_packet)
-
-      update_stats(character)
-
-      push(session, Packets.InventoryItem.remove_item(item.id))
-    end
-  end
-
-  defp unequip_item(character, item, session) do
-    with {:ok, item} <- Context.Equips.unequip(item) do
-      item = Context.Items.load_metadata(item)
-      unequip_packet = Packets.UnequipItem.bytes(character, item.id)
-      Context.Field.broadcast(character, unequip_packet)
-
-      update_stats(character)
-
-      push(session, Packets.InventoryItem.add_item({:create, item}, character))
-    end
-  end
-
-  defp update_stats(character) do
-    {character, _equipment_stats} =
-      character
-      |> Context.Characters.load_equips()
-      |> Context.CharacterStats.apply()
-
-    Managers.Character.call(character, {:update, character})
-    Context.Field.broadcast_stats(character)
-    Context.Field.broadcast(character, Packets.ProxyGameObj.update_gear_score(character))
-  end
 end

--- a/lib/ms2ex/handlers/game/pickup_item.ex
+++ b/lib/ms2ex/handlers/game/pickup_item.ex
@@ -10,7 +10,8 @@ defmodule Ms2ex.GameHandlers.PickupItem do
 
     {:ok, character} = Managers.Character.call(session.character_id, :lookup)
 
-    # TODO check that user inventory is not full
+    # a full inventory leaves the drop on the field; the field manager
+    # removes it only when the pickup succeeded
     Context.Field.pickup_item(character, object_id)
   end
 end

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -112,6 +112,24 @@ defmodule Ms2ex.Managers.Character do
   end
 
   # --------------------------------
+  # Equips
+  # --------------------------------
+
+  def handle_call({:equip_item, item_id, slot_name}, _from, character) do
+    case Character.Equips.equip(character, item_id, slot_name) do
+      {:ok, character} -> {:reply, {:ok, character}, character}
+      :error -> {:reply, :error, character}
+    end
+  end
+
+  def handle_call({:unequip_item, item_id}, _from, character) do
+    case Character.Equips.unequip(character, item_id) do
+      {:ok, character} -> {:reply, {:ok, character}, character}
+      :error -> {:reply, :error, character}
+    end
+  end
+
+  # --------------------------------
   # Skills
   # --------------------------------
 

--- a/lib/ms2ex/managers/character/equips.ex
+++ b/lib/ms2ex/managers/character/equips.ex
@@ -1,0 +1,249 @@
+defmodule Ms2ex.Managers.Character.Equips do
+  @moduledoc """
+  Equip transitions owned by the character process.
+
+  Equipping moves items between inventory and equipment, rebuilds the
+  character's derived stats, and must keep the character's cached equip list
+  coherent: other players' field serialization reads that list through the
+  character manager. A transition therefore runs as one step inside the
+  manager — the request is validated, conflicting items are unequipped into
+  the freed space, the incoming item is equipped, the equip list and stats
+  are refreshed once, and the field plus the owner's client are notified of
+  the result.
+  """
+
+  alias Ms2ex.Context
+  alias Ms2ex.Enums
+  alias Ms2ex.Net
+  alias Ms2ex.Packets
+  alias Ms2ex.Schema
+
+  # slots no equip request may target: the none slot, off-hand (off-hand
+  # items are equipped into either hand instead), and ears
+  @unreachable_slots [:NONE, :OH, :ER]
+
+  # Equips an inventory item into the requested slot, first unequipping the
+  # items that occupy the taken slots. Returns the refreshed character.
+  @spec equip(Schema.Character.t(), integer(), String.t()) ::
+          {:ok, Schema.Character.t()} | :error
+  def equip(character, item_id, slot_name) do
+    case prepare(character, item_id, slot_name) do
+      {:ok, item, equip_slot, conflicts} ->
+        # the slot the item vacates is the preferred destination for the
+        # item unequipped from the target slot
+        preferred_slot = item.inventory_slot
+
+        case Context.Equips.equip(item, equip_slot) do
+          {:ok, item} ->
+            removed = unequip_conflicts(conflicts, equip_slot, preferred_slot)
+            {:ok, commit(character, {:equipped, item}, removed)}
+
+          {:error, _changeset} ->
+            :error
+        end
+
+      :error ->
+        :error
+    end
+  end
+
+  # Moves an equipped item back to the inventory. Returns the refreshed
+  # character.
+  @spec unequip(Schema.Character.t(), integer()) ::
+          {:ok, Schema.Character.t()} | :error
+  def unequip(character, item_id) do
+    case get_item(character, item_id) do
+      %{location: :equipment} = item ->
+        case unequip_item(item, nil) do
+          {:ok, removed} -> {:ok, commit(character, nil, [removed])}
+          :error -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  # validates the request, loads the item's metadata, and resolves which
+  # equipped items conflict with the incoming one
+  defp prepare(character, item_id, slot_name) do
+    with {:ok, item} <- load_inventory_item(character, item_id),
+         :ok <- equippable?(character, item),
+         {:ok, equip_slot} <- requested_slot(item, slot_name),
+         {:ok, equip_slot, conflicts} <- resolve_conflicts(character, item, equip_slot) do
+      {:ok, item, equip_slot, conflicts}
+    else
+      _ ->
+        :error
+    end
+  end
+
+  defp load_inventory_item(character, item_id) do
+    case get_item(character, item_id) do
+      %{location: :inventory} = item ->
+        {:ok, Context.Items.load_metadata(item)}
+
+      _ ->
+        notify(character, :s_item_invalid_do_not_have)
+    end
+  end
+
+  # level, job, and expiry limits must be met before an item can be equipped;
+  # failures are reported to the owner with a localized message box
+  defp equippable?(character, item) do
+    limits = Map.get(item.metadata, :limit, %{})
+
+    cond do
+      character.level < Map.get(limits, :level, 0) ->
+        notify(character, :s_item_err_puton_low_level)
+
+      Context.Inventory.expired?(item) ->
+        notify(character, :s_item_err_puton_expired)
+
+      job_restricted?(character, limits) ->
+        notify(character, :s_item_err_puton_job)
+
+      true ->
+        :ok
+    end
+  end
+
+  # items without job limits can be worn by every job
+  defp job_restricted?(character, limits) do
+    job_limits = Map.get(limits, :job_limits, [])
+    job_limits != [] and Enums.Job.get_value(character.job) not in job_limits
+  end
+
+  # the requested slot must be a slot the item occupies: its primary slot,
+  # with either hand valid for off-hand items
+  defp requested_slot(item, slot_name) do
+    case Context.Equips.valid_slot?(slot_name) do
+      true -> target_slot(item, String.to_existing_atom(slot_name))
+      false -> :error
+    end
+  end
+
+  defp target_slot(_item, slot) when slot in @unreachable_slots, do: :error
+
+  defp target_slot(item, slot) do
+    slots = Map.get(item.metadata, :slots, [])
+
+    if :OH in slots do
+      if slot in [:LH, :RH], do: {:ok, slot}, else: :error
+    else
+      if slot == List.first(slots), do: {:ok, slot}, else: :error
+    end
+  end
+
+  # Equipped items occupying the slots the incoming item takes over. Off-hand
+  # items replace whatever is in the targeted hand; every other item takes
+  # over all the slots it covers. Items covering multiple slots (two-handed
+  # weapons, suits) additionally need enough free inventory space to hold
+  # everything that will be unequipped: the vacated slot plus one per
+  # displaced item.
+  defp resolve_conflicts(character, item, equip_slot) do
+    conflict_slots =
+      if :OH in item.metadata.slots, do: [equip_slot], else: item.metadata.slots
+
+    conflicts =
+      Enum.filter(
+        character.equips,
+        &(&1.equip_slot in conflict_slots and &1.inventory_tab == item.inventory_tab)
+      )
+
+    if multi_slot?(item) do
+      free_slots = Context.Inventory.free_slot_count(character.id, item.inventory_tab)
+
+      if free_slots + 1 > length(conflicts) do
+        {:ok, equip_slot, conflicts}
+      else
+        :error
+      end
+    else
+      {:ok, equip_slot, conflicts}
+    end
+  end
+
+  defp multi_slot?(item), do: length(item.metadata.slots) > 1
+
+  defp notify(character, string_code) do
+    code = Enums.StringCode.get_value(string_code)
+    Net.SenderSession.push(character, Packets.Notice.message_box(code))
+    :error
+  end
+
+  # Moves an equipped item out of its slot. Returns `{:ok, {kind, item}}`
+  # where the item was either unequipped back to the inventory (`:unequipped`)
+  # or discarded as a cosmetic (`:discarded`).
+  defp unequip_item(item, preferred_slot) do
+    case Context.Equips.unequip(item, preferred_slot) do
+      {:ok, item} -> {:ok, {:unequipped, item}}
+      {:discard, item} -> {:ok, {:discarded, item}}
+      {:error, _reason} -> :error
+    end
+  end
+
+  # the item displaced from the requested slot is unequipped first so it can
+  # claim the vacated inventory slot
+  defp unequip_conflicts(conflicts, equip_slot, preferred_slot) do
+    {primary, others} = Enum.split_with(conflicts, &(&1.equip_slot == equip_slot))
+    ordered = primary ++ others
+
+    ordered
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {item, index} ->
+      destination = if index == 0, do: preferred_slot, else: nil
+
+      case unequip_item(item, destination) do
+        {:ok, removed} -> [removed]
+        :error -> []
+      end
+    end)
+  end
+
+  defp get_item(character, item_id) do
+    Context.Inventory.get_by(character_id: character.id, id: item_id)
+  end
+
+  # refreshes the cached equip list and derived stats once for the whole
+  # transition, then announces the result to the field and the owner's
+  # client; `equipped` is nil when the transition ended without a new equip
+  defp commit(character, equipped, removed) do
+    character = refresh(character)
+
+    Enum.each(removed, fn {_kind, item} ->
+      Context.Field.broadcast(character, Packets.UnequipItem.bytes(character, item.id))
+    end)
+
+    if equipped do
+      Context.Field.broadcast(character, Packets.EquipItem.bytes(character, elem(equipped, 1)))
+    end
+
+    Context.Field.broadcast_stats(character)
+    Context.Field.broadcast(character, Packets.ProxyGameObj.update_gear_score(character))
+
+    Enum.each(removed, fn
+      {:unequipped, item} ->
+        Net.SenderSession.push(
+          character,
+          Packets.InventoryItem.add_item({:create, item}, character)
+        )
+
+      {:discarded, _item} ->
+        :ok
+    end)
+
+    if equipped do
+      Net.SenderSession.push(character, Packets.InventoryItem.remove_item(elem(equipped, 1).id))
+    end
+
+    character
+  end
+
+  defp refresh(character) do
+    character
+    |> Context.Characters.load_equips()
+    |> Context.CharacterStats.apply()
+    |> elem(0)
+  end
+end

--- a/lib/ms2ex/managers/field/item.ex
+++ b/lib/ms2ex/managers/field/item.ex
@@ -6,52 +6,68 @@ defmodule Ms2ex.Managers.Field.Item do
   alias Ms2ex.Packets
 
   def pickup_item(character, item, state) do
-    cond do
-      Context.Items.mesos?(item) ->
-        Context.Wallets.update(character, :mesos, item.amount)
+    credit = consumable_credit(item)
 
-      Context.Items.valor_token?(item) ->
-        Context.Wallets.update(character, :valor_tokens, item.amount)
-
-      Context.Items.merets?(item) ->
-        Context.Wallets.update(character, :merets, item.amount)
-
-      Context.Items.rue?(item) ->
-        Context.Wallets.update(character, :rues, item.amount)
-
-      Context.Items.havi_fruit?(item) ->
-        Context.Wallets.update(character, :havi_fruits, item.amount)
-
-      Context.Items.sp?(item) ->
-        Managers.Character.cast(character, {:increase_stats, [spirit: item.amount]})
-
-      Context.Items.stamina?(item) ->
-        Managers.Character.cast(character, {:increase_stats, [stamina: item.amount]})
-
-      true ->
-        item =
-          item
-          |> Context.Items.load_metadata()
-          |> Context.Items.bind_if_needed(:loot)
-
-        with {:ok, result} <- Context.Inventory.add_item(character, item) do
-          {_status, item} = result
-          push(character, Packets.InventoryItem.add_item(result, character))
-          push(character, Packets.InventoryItem.mark_item_new(item))
-
-          # pickup-count quest conditions; code param carries the item id
-          Managers.Quest.update_conditions(
-            character.id,
-            :item_pickup,
-            item.amount,
-            "",
-            0,
-            "",
-            item.item_id
-          )
-        end
+    if credit do
+      apply_credit(character, credit, item.amount)
+      remove_item(character, item, state)
+    else
+      pickup_inventory_item(character, item, state)
     end
+  end
 
+  # field items that convert directly into a wallet balance or a stat
+  defp consumable_credit(item) do
+    cond do
+      Context.Items.mesos?(item) -> {:wallet, :mesos}
+      Context.Items.valor_token?(item) -> {:wallet, :valor_tokens}
+      Context.Items.merets?(item) -> {:wallet, :merets}
+      Context.Items.rue?(item) -> {:wallet, :rues}
+      Context.Items.havi_fruit?(item) -> {:wallet, :havi_fruits}
+      Context.Items.sp?(item) -> {:stat, :spirit}
+      Context.Items.stamina?(item) -> {:stat, :stamina}
+      true -> nil
+    end
+  end
+
+  defp apply_credit(character, {:wallet, currency}, amount),
+    do: Context.Wallets.update(character, currency, amount)
+
+  defp apply_credit(character, {:stat, stat}, amount),
+    do: Managers.Character.cast(character, {:increase_stats, [{stat, amount}]})
+
+  defp pickup_inventory_item(character, item, state) do
+    item =
+      item
+      |> Context.Items.load_metadata()
+      |> Context.Items.bind_if_needed(:loot)
+
+    case Context.Inventory.add_item(character, item) do
+      {:ok, result} ->
+        {_status, item} = result
+        push(character, Packets.InventoryItem.add_item(result, character))
+        push(character, Packets.InventoryItem.mark_item_new(item))
+
+        # pickup-count quest conditions; code param carries the item id
+        Managers.Quest.update_conditions(
+          character.id,
+          :item_pickup,
+          item.amount,
+          "",
+          0,
+          "",
+          item.item_id
+        )
+
+        remove_item(character, item, state)
+
+      # the inventory cannot hold the item; it stays on the field
+      {:error, _changeset} ->
+        state
+    end
+  end
+
+  defp remove_item(character, item, state) do
     Context.Field.broadcast(state.topic, Packets.FieldPickupItem.bytes(character, item))
     Context.Field.broadcast(state.topic, Packets.FieldRemoveItem.bytes(item.object_id))
 
@@ -70,9 +86,7 @@ defmodule Ms2ex.Managers.Field.Item do
     }
 
     Context.Field.broadcast(state.topic, Packets.FieldAddItem.add_item(item))
-
-    items = Map.put(state.items, object_id, item)
-    %{state | items: items}
+    store(state, item)
   end
 
   def add_mob_drop(mob, item, receiver \\ nil, state) do
@@ -90,8 +104,13 @@ defmodule Ms2ex.Managers.Field.Item do
     }
 
     Context.Field.broadcast(state.topic, Packets.FieldAddItem.add_item(item))
+    store(state, item)
+  end
 
-    items = Map.put(state.items, object_id, item)
+  # metadata is re-read from the storage cache when the item is picked up;
+  # it is not kept in the field state
+  defp store(state, item) do
+    items = Map.put(state.items, item.object_id, %{item | metadata: nil})
     %{state | items: items}
   end
 

--- a/lib/ms2ex/packets/game/character_info.ex
+++ b/lib/ms2ex/packets/game/character_info.ex
@@ -17,10 +17,9 @@ defmodule Ms2ex.Packets.CharacterInfo do
   end
 
   def load(%Schema.Character{} = character) do
-    {character, equipment_stats} =
-      character
-      |> Context.Characters.load_equips()
-      |> Context.CharacterStats.apply()
+    # the character comes from the manager, so its equip list is already
+    # current; only the derived stats need rebuilding
+    {character, equipment_stats} = Context.CharacterStats.apply(character)
 
     __MODULE__
     |> build()

--- a/lib/ms2ex/packets/game/inventory_item.ex
+++ b/lib/ms2ex/packets/game/inventory_item.ex
@@ -96,7 +96,7 @@ defmodule Ms2ex.Packets.InventoryItem do
     |> put_time(item.unlocks_at)
     |> put_short(item.glamor_forges_left)
     |> put_bool(false)
-    # TODO gacha dismantle id
+    # TODO gacha dismantle id (always 0 until gacha items are supported)
     |> put_int()
     |> put_appearance(item)
     |> put_item_stats(item)
@@ -110,8 +110,9 @@ defmodule Ms2ex.Packets.InventoryItem do
     |> put_int(item.charges)
     |> put_item_enchant_stats(item)
     # |> put_template(item)
-    # TODO put pets
-    # TODO put gem slot
+    # TODO put pets (no pet support yet: pet items would write their info block here)
+    # TODO put gem slot (socket unlock and gemstones unimplemented; only the
+    #      empty socket block is written)
     |> put_int(TransferFlags.to_int(item.transfer_flags))
     |> put_byte()
     |> put_int(item.remaining_trades)

--- a/test/ms2ex/equips_test.exs
+++ b/test/ms2ex/equips_test.exs
@@ -1,12 +1,17 @@
 defmodule Ms2ex.EquipsTest do
-  use Ms2ex.DataCase, async: true
+  # the transitions spawn character processes that read the stubbed metadata
+  # from another process, so the stubs must be visible globally
+  use Ms2ex.DataCase, async: false
 
   alias Ms2ex.Context
+  alias Ms2ex.Managers
   alias Ms2ex.Schema
 
+  setup {Mimic, :set_mimic_global}
+
   setup do
-    # BindOnEquip staff metadata (item 15260310 from the dev seed)
     stub_metadata(%{
+      # BindOnEquip staff metadata (item 15260310 from the dev seed)
       "item:15260310" => %{
         limit: %{
           level: 70,
@@ -48,4 +53,265 @@ defmodule Ms2ex.EquipsTest do
     assert reloaded.remaining_trades == 0
     assert reloaded.location == :equipment
   end
+
+  # ---- slot allocation ----
+
+  test "slot allocation is bounded by the tab's slot count" do
+    character = insert_character()
+    Repo.insert!(%Schema.InventoryTab{character_id: character.id, tab: :gear, slots: 3})
+
+    insert_gear_item(character.id, 0)
+    insert_gear_item(character.id, 1)
+
+    assert Context.Inventory.find_first_available_slot(character.id, :gear) == 2
+
+    insert_gear_item(character.id, 2)
+
+    assert Context.Inventory.find_first_available_slot(character.id, :gear) ==
+             {:error, :full_inventory}
+
+    assert Context.Inventory.free_slot_count(character.id, :gear) == 0
+
+    # expanding the tab raises the bound
+    tab = Repo.get_by(Schema.InventoryTab, character_id: character.id, tab: :gear)
+    Repo.update!(Schema.InventoryTab.changeset(tab, %{slots: 5}))
+
+    assert Context.Inventory.find_first_available_slot(character.id, :gear) == 3
+    assert Context.Inventory.free_slot_count(character.id, :gear) == 2
+  end
+
+  test "unequip prefers a free slot and falls back when it is taken" do
+    character = insert_character()
+    Repo.insert!(%Schema.InventoryTab{character_id: character.id, tab: :gear, slots: 3})
+
+    insert_gear_item(character.id, 0)
+
+    equipped = insert_equip_item(character.id, :RH)
+    {:ok, item} = Context.Equips.unequip(equipped, 0)
+    # slot 0 is occupied, so the item lands in the first open slot
+    assert item.inventory_slot == 1
+
+    equipped = insert_equip_item(character.id, :RH)
+    {:ok, item} = Context.Equips.unequip(equipped, 2)
+    # slot 2 is free, so the preference is honored
+    assert item.inventory_slot == 2
+  end
+
+  # ---- equip transitions (character manager) ----
+
+  test "equipping a two-slot item unequips everything it covers" do
+    stub_metadata(%{
+      "item:3001" => item_meta([5, 4], %{level: 10}),
+      "item:3002" => item_meta([5], %{level: 10}),
+      "item:3003" => item_meta([19], %{level: 10})
+    })
+
+    character = insert_character()
+
+    staff = add_inventory_item(character, 3001)
+    sword = equip_item(character, 3002, :RH)
+    shield = equip_item(character, 3003, :LH)
+
+    character = %{character | equips: Context.Equips.list(character)}
+    start_character(character)
+
+    assert {:ok, character} = Managers.Character.call(character, {:equip_item, staff.id, "RH"})
+
+    # the staff covers both hands, so the sword and the shield return to the
+    # inventory and only the staff stays equipped
+    assert equips(character) == [:RH]
+
+    assert Repo.reload!(sword).location == :inventory
+    assert Repo.reload!(shield).location == :inventory
+
+    staff_row = Repo.reload!(staff)
+    assert staff_row.location == :equipment
+    assert staff_row.equip_slot == :RH
+
+    reloaded = Managers.Character.call(character.id, :lookup) |> elem(1)
+    assert equips(reloaded) == [:RH]
+  end
+
+  test "equipping pants over a suit keeps the suit equipped" do
+    stub_metadata(%{
+      "item:3101" => item_meta([8, 9], %{level: 10, is_skin: true}),
+      "item:3102" => item_meta([9], %{level: 10, is_skin: true})
+    })
+
+    character = insert_character()
+
+    suit = equip_item(character, 3101, :CL)
+    pants = add_inventory_item(character, 3102)
+
+    character = %{character | equips: Context.Equips.list(character)}
+    start_character(character)
+
+    assert {:ok, character} = Managers.Character.call(character, {:equip_item, pants.id, "PA"})
+
+    # the suit only occupies the clothing slot, so the pants join it instead
+    # of displacing it
+    assert character |> equips() |> Enum.sort() == [:CL, :PA]
+
+    assert Repo.reload!(suit).location == :equipment
+    assert Repo.reload!(pants).location == :equipment
+
+    reloaded = Managers.Character.call(character.id, :lookup) |> elem(1)
+    assert reloaded |> equips() |> Enum.sort() == [:CL, :PA]
+  end
+
+  test "equipping fails for a slot the item does not occupy" do
+    stub_metadata(%{"item:3101" => item_meta([8, 9], %{level: 10, is_skin: true})})
+
+    character = insert_character()
+    suit = add_inventory_item(character, 3101)
+
+    character = %{character | equips: Context.Equips.list(character)}
+    start_character(character)
+
+    # the suit occupies clothing first; the pants slot is not a valid target
+    assert :error = Managers.Character.call(character, {:equip_item, suit.id, "PA"})
+
+    assert Repo.reload!(suit).location == :inventory
+    assert [] == equips(Managers.Character.call(character.id, :lookup) |> elem(1))
+  end
+
+  test "equipping fails for an item above the character's level" do
+    stub_metadata(%{"item:3201" => item_meta([6], %{level: 999})})
+
+    character = insert_character(level: 10)
+    hat = add_inventory_item(character, 3201)
+
+    character = %{character | equips: Context.Equips.list(character)}
+    start_character(character)
+
+    assert :error = Managers.Character.call(character, {:equip_item, hat.id, "CP"})
+    assert_received {:push, <<0x73::little-16, 4::8, 64::little-16, _::binary>>}
+
+    assert Repo.reload!(hat).location == :inventory
+  end
+
+  test "equipping fails for an item with foreign job limits" do
+    stub_metadata(%{"item:3202" => item_meta([5], %{level: 10, job_limits: [30]})})
+
+    character = insert_character(job: :knight)
+    blade = add_inventory_item(character, 3202)
+
+    character = %{character | equips: Context.Equips.list(character)}
+    start_character(character)
+
+    assert :error = Managers.Character.call(character, {:equip_item, blade.id, "RH"})
+    assert Repo.reload!(blade).location == :inventory
+  end
+
+  test "unequipping discards cosmetic looks" do
+    stub_metadata(%{"item:3301" => item_meta([1], %{level: 10})})
+
+    character = insert_character()
+    hair = equip_item(character, 3301, :HR)
+
+    character = %{character | equips: Context.Equips.list(character)}
+    start_character(character)
+
+    assert {:ok, character} = Managers.Character.call(character, {:unequip_item, hair.id})
+
+    # the look cannot be worn again, so the item is gone entirely
+    assert Repo.get(Schema.Item, hair.id) == nil
+    assert [] == equips(character)
+    assert [] == equips(Managers.Character.call(character.id, :lookup) |> elem(1))
+  end
+
+  # ---- helpers ----
+
+  defp item_meta(slot_names, limit_overrides) do
+    limit =
+      Map.merge(
+        %{
+          level: 10,
+          gender: 2,
+          job_limits: [],
+          job_recommends: [],
+          transfer_type: 3,
+          trade_max_rarity: 4
+        },
+        limit_overrides
+      )
+
+    %{
+      limit: limit,
+      property: %{
+        type: 1,
+        is_skin: Map.get(limit_overrides, :is_skin, false),
+        ride: 0,
+        tradable_count: 1
+      },
+      slot_names: slot_names,
+      option: %{constant_id: 0, pick_id: 0, static_id: 0, random_id: 0}
+    }
+  end
+
+  defp insert_character(overrides \\ []) do
+    account =
+      Repo.insert!(%Schema.Account{
+        username: "equips_#{System.unique_integer([:positive])}",
+        password_hash: "x"
+      })
+
+    character =
+      Repo.insert!(%Schema.Character{
+        account_id: account.id,
+        name: "EqTest#{System.unique_integer([:positive])}",
+        job: Keyword.get(overrides, :job, :knight),
+        level: Keyword.get(overrides, :level, 60),
+        map_id: 1,
+        skin_color: {}
+      })
+
+    stats = Repo.insert!(%Schema.CharacterStats{character_id: character.id})
+    %{character | stats: stats, sender_session_pid: self()}
+  end
+
+  defp start_character(character) do
+    {:ok, pid} = Managers.Character.start(character)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+    pid
+  end
+
+  defp add_inventory_item(character, item_id) do
+    item = Context.Items.init(item_id, %{rarity: 1, amount: 1})
+    {:ok, {:create, item}} = Context.Inventory.add_item(character, item)
+    item
+  end
+
+  defp equip_item(character, item_id, equip_slot) do
+    item = add_inventory_item(character, item_id)
+    {:ok, item} = Context.Equips.equip(item |> Context.Items.load_metadata(), equip_slot)
+    item
+  end
+
+  defp insert_equip_item(character_id, equip_slot, overrides \\ []) do
+    Repo.insert!(%Schema.Item{
+      character_id: character_id,
+      item_id: Keyword.get(overrides, :item_id, 4001),
+      amount: 1,
+      rarity: 1,
+      location: :equipment,
+      inventory_tab: Keyword.get(overrides, :inventory_tab, :gear),
+      equip_slot: equip_slot
+    })
+  end
+
+  defp insert_gear_item(character_id, slot) do
+    Repo.insert!(%Schema.Item{
+      character_id: character_id,
+      item_id: 4002,
+      amount: 1,
+      rarity: 1,
+      location: :inventory,
+      inventory_tab: :gear,
+      inventory_slot: slot
+    })
+  end
+
+  defp equips(character), do: Enum.map(character.equips, & &1.equip_slot)
 end


### PR DESCRIPTION
## Summary

Extracts the equip domain into a `Managers.Character.Equips` submodule owned by the character process (roadmap item 16). Handlers now issue **one** manager call per equip/unequip packet instead of orchestrating half a dozen context calls; the character process owns the transition — validation, conflict resolution, item persistence, equip-list + derived-stats refresh, and field/client notification — and stores the fresh state directly (no `{:update, ...}` push-back round trip).

Deliberately a module split, **not** a separate GenServer: equips are read constantly by field serialization of other players and are items (see item 15), so a standalone equip process would fragment item state across two owners.

## Changes

**Equip transition parity**
- Request validation in the reference order: item in inventory (`s_item_invalid_do_not_have`), level/expiry/job limits (`s_item_err_puton_low_level` / `_expired` / `_job`), then target-slot rules — the requested slot must be the item's primary slot, either hand for off-hand items, `{NONE, OH, ER}` unreachable.
- Multi-slot pre-check: two-handed weapons/suits require `free_slots + 1 > displaced` before any write.
- Conflict resolution & ordering: the equip write happens first (frees the source item's slot), the item displaced from the requested slot claims it, remaining conflicts allocate open slots; stats/gear-score broadcast once per transition instead of once per displaced item.
- Pants no longer displace an equipped suit (suits live on their primary CL slot); a full inventory now refuses the unequip instead of leaving two items in one slot.
- Cosmetic looks (hair, ears, face, face decal) are **discarded** on unequip — matching the one-time-look behavior — with the unequip broadcast still firing.
- Full inventory on pickup leaves the drop on the field instead of silently destroying it (closes the `pickup_item` TODO).

**Slot allocation**
- `find_first_available_slot/2` scans `0..(tab_size - 1)` from the character's persisted `inventory_tabs.slots` (base + expansions) instead of a hardcoded `0..149` (closes that TODO); new `free_slot_count/2` feeds the pre-check.

**Memory**
- Manager state carries no item metadata: the cached equip list and field drops hold plain item rows; stat rebuilds, gear score, and pickup fetch metadata from the storage cache (ETS) at point of use. Remaining holders (NPC, quest, buff documents) tracked separately.

**Serialization**
- `CharacterInfo` reads the manager's equip list instead of re-querying; remaining item-packet TODOs (gacha dismantle id, pet block, gem sockets) annotated precisely — serialization already matches the default shapes.

## Roadmap

- Item 16 → completed; item 15 updated (slot allocation folds into the inventory owner)
- New item 17 (gem sockets / pet items / gacha) and item 18 (metadata-free manager state for NPC/quest/buff documents)
- Item 4 notes item-granted buffs as unapplied/unremoved on unequip

## Testing

- `mix test` — 163 passed (8 new equip-transition tests: tab-bounded allocation + expansion, preferred-slot fallback, two-slot displacement, pants-over-suit coexistence, slot-target rejection, level/job-limit rejection with message-box assert, cosmetic discard)
- `mix credo` clean, `mix format --check-formatted` clean
- Reference comparison notes in `docs/internal/equip-parity.md` (git-ignored)
- Needs in-game verification against the client before merge