### PR TITLE
Fix field pickup emitting a zero object id

### DIFF
--- a/lib/ms2ex/managers/field/item.ex
+++ b/lib/ms2ex/managers/field/item.ex
@@ -44,19 +44,19 @@ defmodule Ms2ex.Managers.Field.Item do
 
     case Context.Inventory.add_item(character, item) do
       {:ok, result} ->
-        {_status, item} = result
+        {_status, inventory_item} = result
         push(character, Packets.InventoryItem.add_item(result, character))
-        push(character, Packets.InventoryItem.mark_item_new(item))
+        push(character, Packets.InventoryItem.mark_item_new(inventory_item))
 
         # pickup-count quest conditions; code param carries the item id
         Managers.Quest.update_conditions(
           character.id,
           :item_pickup,
-          item.amount,
+          inventory_item.amount,
           "",
           0,
           "",
-          item.item_id
+          inventory_item.item_id
         )
 
         remove_item(character, item, state)

--- a/test/ms2ex/field_item_pickup_test.exs
+++ b/test/ms2ex/field_item_pickup_test.exs
@@ -1,0 +1,78 @@
+defmodule Ms2ex.FieldItemPickupTest do
+  use Ms2ex.DataCase, async: true
+
+  alias Ms2ex.Managers.Field.Item
+  alias Ms2ex.Schema
+  alias Ms2ex.Types
+
+  @object_id 7
+  @item_id 4_000_001
+
+  setup do
+    stub_metadata(%{
+      "item:#{@item_id}" => %{
+        limit: %{level: 10, transfer_type: 3},
+        property: %{type: 1},
+        slot_names: [5],
+        option: %{constant_id: 0, pick_id: 0, static_id: 0, random_id: 0}
+      }
+    })
+
+    character = insert_character()
+
+    # the removal packets are broadcast on the field topic
+    Phoenix.PubSub.subscribe(Ms2ex.PubSub, "field:1:channel:1")
+
+    state = %{
+      topic: :"field:1:channel:1",
+      items: %{@object_id => field_item()}
+    }
+
+    %{character: character, state: state}
+  end
+
+  test "picking up a field item removes it by its object id", %{
+    character: character,
+    state: state
+  } do
+    state = Item.pickup_item(character, field_item(), state)
+
+    # the field item is gone from the field state
+    assert state.items == %{}
+
+    # the removal packets name the real object id, not the fresh inventory row
+    assert_received {:push, <<0x2D::little-16, 1::8, @object_id::little-32, _::binary>>}
+    assert_received {:push, <<0x2C::little-16, @object_id::little-32>>}
+  end
+
+  defp field_item do
+    %Schema.Item{
+      object_id: @object_id,
+      item_id: @item_id,
+      amount: 1,
+      rarity: 1,
+      stats: %Types.ItemStats{}
+    }
+  end
+
+  defp insert_character do
+    account =
+      Repo.insert!(%Schema.Account{
+        username: "pickup_#{System.unique_integer([:positive])}",
+        password_hash: "x"
+      })
+
+    character =
+      Repo.insert!(%Schema.Character{
+        account_id: account.id,
+        name: "Pickup#{System.unique_integer([:positive])}",
+        job: :knight,
+        level: 10,
+        map_id: 1,
+        skin_color: {}
+      })
+
+    stats = Repo.insert!(%Schema.CharacterStats{character_id: character.id})
+    %{character | stats: stats, sender_session_pid: self()}
+  end
+end


### PR DESCRIPTION
## Summary

Regular item pickups (everything that lands in the inventory — e.g. quest items and gear) emitted `FieldPickupItem` / `FieldRemoveItem` with **object id 0**:

```
[RECV] PICKUP_ITEM (0x1C): 51 F1 FA 02 00
[SEND] FIELD_PICKUP_ITEM (0x2D): 01 00 00 00 00 81 96 98 00   ← object id 0
[SEND] FIELD_REMOVE_ITEM (0x2C): 00 00 00 00                  ← object id 0
```

The client therefore never removed the item from the field (it kept rendering it), and the server's field-state cleanup deleted key `0` instead of the real entry — the item stayed in field state, so walking over it again would add it to the inventory **again** (duping). Mesos / SP orbs / havi fruit were unaffected because their branch never rebinding the item.

## Root cause

The pickup restructure in #102 moved the field-item removal into the `add_item` success branch, where `add_item`'s result (the **fresh inventory row**, `object_id: 0`) shadowed the field item — the removal broadcast and `Map.delete` then operated on the inventory row's id.

## Fix

Keep the field item for the removal broadcast and state cleanup; use the inventory row only for the inventory packets and quest-condition updates (same split the pre-#102 code had, now with the full-inventory guard preserved).

## Testing

- New regression test `field_item_pickup_test.exs`: drives `Field.Item.pickup_item/3` directly and asserts the field item leaves the state and both removal packets carry the real object id (fails without the fix)
- 164 tests passing, credo clean