### PR TITLE
Fall back to the map spawn when a portal has no return link

### DIFF
--- a/lib/ms2ex/handlers/game/request_change_field.ex
+++ b/lib/ms2ex/handlers/game/request_change_field.ex
@@ -16,18 +16,26 @@ defmodule Ms2ex.GameHandlers.RequestChangeField do
 
     {current_map_id, packet} = get_int(packet)
 
-    with true <- current_map_id == character.map_id,
-         portals <- Storage.Maps.get_portals(current_map_id),
-         {src_portal_id, _packet} = get_int(packet),
-         %{target_map_id: dst_map_id} <- find_portal(portals, src_portal_id),
-         dst_map_portals <- Storage.Maps.get_portals(dst_map_id),
-         spawn_point <- find_spawn_point(dst_map_portals, current_map_id) do
-      Context.Field.change_field(
-        character,
-        dst_map_id,
-        spawn_point.position,
-        spawn_point.rotation
-      )
+    if current_map_id == character.map_id do
+      portals = Storage.Maps.get_portals(current_map_id)
+      {src_portal_id, _packet} = get_int(packet)
+
+      case find_portal(portals, src_portal_id) do
+        %{target_map_id: dst_map_id} ->
+          spawn_point = arrival_point(dst_map_id, current_map_id)
+
+          Context.Field.change_field(
+            character,
+            dst_map_id,
+            spawn_point.position,
+            spawn_point.rotation
+          )
+
+        _ ->
+          session
+      end
+    else
+      session
     end
   end
 
@@ -37,7 +45,14 @@ defmodule Ms2ex.GameHandlers.RequestChangeField do
     Enum.find(portals, &(&1.id == portal_id))
   end
 
-  defp find_spawn_point(portals, map_id) do
-    Enum.find(portals, &(&1.target_map_id == map_id))
+  # the destination's portal leading back to the current map is the arrival
+  # point; maps without a return portal use their default spawn point
+  defp arrival_point(dst_map_id, current_map_id) do
+    portal =
+      dst_map_id
+      |> Storage.Maps.get_portals()
+      |> Enum.find(&(&1.target_map_id == current_map_id))
+
+    portal || Storage.Maps.get_spawn(dst_map_id)
   end
 end


### PR DESCRIPTION
## Summary

Changing field through a portal whose destination map has no portal leading back to the current map crashed the handler:

```
[RECV] REQUEST_CHANGE_FIELD (0x6D): 00 45 C3 19 03 ...
** (BadMapError) expected a map, got: nil
    request_change_field.ex:28 in handle_change_field/3
```

`find_spawn_point/2` returned `nil` (no return portal on the destination) and the handler dereferenced it for the arrival position/rotation. Any one-way portal pair — e.g. housing maps — reproduces this; unrelated to the equip work, just surfaced while testing.

## Fix

- The arrival point is the destination's **return portal** when one exists, else the map's **default spawn point** (`Storage.Maps.get_spawn/1`)
- An unknown source portal or a stale `current_map_id` is ignored instead of raising a `CaseClauseError` (the `with` had no `else`)

## Testing

- 164 tests passing, credo clean, format clean
- Manual: portal transitions through maps without return portals now land at the destination's default spawn