### PR TITLE
Achievement manager: in-memory progress, no per-event queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,10 @@ host runs):
   disconnect (the quest, inventory, and achievement managers are the model).
   Handlers orchestrate through managers and never run queries directly;
   pre-session flows (character creation, login listings, seeds) write the
-  database through contexts.
+  database through contexts. State owned by a manager is never mirrored
+  onto the character struct — readers query the owning manager, and
+  contexts receive the data they need as arguments (see `Context.ItemStats`
+  taking the equipped items).
 - **Matching the reference implementation's behavior is the standing,
   assumed goal — never mention it in comments or code.** Comments must
   describe behavior in domain terms only (what the server does and why),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,15 @@ host runs):
 
 ## Architecture notes
 
+- **Contexts persist, managers own state.** A context module
+  (`Ms2ex.Context.*`) contains only database reads and writes — no
+  processes, no packets, no manager references. Per-character or per-session
+  state lives in a manager (`Ms2ex.Managers.*`) GenServer that owns it in
+  memory, calls contexts to persist, and is started at login and stopped on
+  disconnect (the quest, inventory, and achievement managers are the model).
+  Handlers orchestrate through managers and never run queries directly;
+  pre-session flows (character creation, login listings, seeds) write the
+  database through contexts.
 - **Matching the reference implementation's behavior is the standing,
   assumed goal — never mention it in comments or code.** Comments must
   describe behavior in domain terms only (what the server does and why),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -416,6 +416,17 @@ combat-heavy characters from accumulating document copies.
 
 ## Recently completed
 
+- Quest condition batching: quest condition counters accumulate in memory
+  in the quest manager and mark quests dirty for a periodic flush (also
+  flushed on demand and on stop) — ordinary gameplay events (kills,
+  movement, pickups) no longer write one UPDATE per matching quest per
+  event. Quest transitions that own their persistence (start, complete,
+  abandon, expire) still write through
+- Equipped items are no longer mirrored on the character struct: field
+  appearance, character info, stat rebuilds and conflict resolution read
+  the inventory manager at point of use, and `Context.ItemStats` takes
+  the equipped items as an argument so contexts stay free of manager
+  reads (same treatment as the mirrored trophy counts before them)
 - Achievement manager: `Managers.Achievement`
   (`achievements:<char_id>`, like the quest manager) owns every achievement
   row in memory — condition events walk the metadata index without touching

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -422,6 +422,12 @@ combat-heavy characters from accumulating document copies.
   movement, pickups) no longer write one UPDATE per matching quest per
   event. Quest transitions that own their persistence (start, complete,
   abandon, expire) still write through
+- Auto-start gating: quests carrying an event tag never start on their own
+  (event content starts only through a matching server event, and stale
+  event quests would otherwise be auto-started at login and immediately
+  expired by the client in an insert/delete churn). The client expiration
+  sweep now drops expired rows in one DELETE per owner scope instead of
+  one per quest
 - Equipped items are no longer mirrored on the character struct: field
   appearance, character info, stat rebuilds and conflict resolution read
   the inventory manager at point of use, and `Context.ItemStats` takes

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -423,7 +423,11 @@ combat-heavy characters from accumulating document copies.
   flush (and a flush on disconnect). Trophy counts live on the manager and
   sync onto the character, grade completions notify quest conditions, stat
   point and emote rewards apply on rank-up while item and title rewards wait
-  for the claim, and `Context.Achievements` shrank to pure persistence
+  for the claim, and `Context.Achievements` shrank to pure persistence.
+  Meta-trophies that track other achievements (`revise_achieve_*`,
+  `hero_achieve`) gate on the completing achievement id and reached grade —
+  without the gate a single map-visit trophy cascaded into dozens of
+  meta-trophy unlocks at login
 - Character-owned inventory manager: `Managers.Inventory`
   (`inventories:<char_id>`, like the quest manager) owns every item row and
   tab size of a character in memory — reads from memory, write-through

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -193,10 +193,17 @@ minimum-value / allowed-value gates.
 
 Completion and acceptance commit the quest row, turn-in item consumption
 (`item_exist` conditions) and item rewards atomically in one transaction;
-exp and currencies are granted post-commit. Non-
-forfeitable quests refuse abandon, the expiration sweep drops rows and
-notifies the client, and go-to-npc travel moves the character to the quest's
-destination map.
+exp and currencies are granted post-commit. Condition-counter changes from
+gameplay events accumulate in memory and batch into a periodic flush (also
+on demand and on stop) instead of one UPDATE per matching quest per event.
+Non-forfeitable quests refuse abandon, the expiration sweep drops expired
+rows in one statement per owner scope and notifies the client, and
+go-to-npc travel moves the character to the quest's destination map.
+Event-tagged quests never start on their own: event content starts only
+through a matching server event, so stale event quests no longer churn
+through auto-start plus client-side expiry at login. Event-tagged quests never start on their own: event
+content starts only through a matching server event, so stale event quests
+no longer churn through auto-start plus client-side expiry at login.
 What is still missing:
 
 - multi-page npc dialogue walking (Continue tracking) and script functions
@@ -221,8 +228,9 @@ deliver configured item or stat-point rewards. Achievement state is owned by
 disconnect): rows load once, condition events walk the storage index in
 memory, new rows are inserted as they are created, and updates batch into a
 periodic flush (also flushed on demand and on stop) — no per-event queries.
-Trophy counts per category are kept in memory and pushed onto the character,
-grade completions feed back into quest conditions (`revise_achieve_*`,
+Trophy counts per category live on the manager and are read from it (the
+character struct keeps no mirrored copy), grade completions feed back into
+quest conditions (`revise_achieve_*`,
 `hero_achieve`), stat-point and emote rewards are granted automatically on
 rank-up while item and title rewards wait for the manual claim, and load
 packets are batched per 60 entries. Riding distance is tracked from mounted

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -216,15 +216,21 @@ What is still missing:
 
 Achievement metadata is ingested with a condition-type index, and completed
 field missions now activate exploration quests, advance milestone progress and
-deliver configured item or stat-point rewards. Achievement state persists per
-account or character, loads on field entry, receives the existing gameplay
-condition events, records completed grades, supports favorite toggles, and
-allows manual claims for item, title, and stat-point rewards. A claim request
-processes every pending grade. Riding distance is tracked from mounted sync
-updates and advances `riding` conditions per 150 units travelled.
+deliver configured item or stat-point rewards. Achievement state is owned by
+`Managers.Achievement` (`achievements:<char_id>`, started at login, stopped on
+disconnect): rows load once, condition events walk the storage index in
+memory, new rows are inserted as they are created, and updates batch into a
+periodic flush (also flushed on demand and on stop) — no per-event queries.
+Trophy counts per category are kept in memory and pushed onto the character,
+grade completions feed back into quest conditions (`revise_achieve_*`,
+`hero_achieve`), stat-point and emote rewards are granted automatically on
+rank-up while item and title rewards wait for the manual claim, and load
+packets are batched per 60 entries. Riding distance is tracked from mounted
+sync updates and advances `riding` conditions per 150 units travelled.
 
 What is still missing:
 
+- skill point rewards stay pending (no skill point API exists yet)
 - condition matching limitations shared by quests, exploration, and
   achievements: `party_count` and `guild_party_count` gates are ignored;
   string-code conditions (`emotion`, `emotiontime`, `trigger`, `npc_race`) and
@@ -410,6 +416,14 @@ combat-heavy characters from accumulating document copies.
 
 ## Recently completed
 
+- Achievement manager: `Managers.Achievement`
+  (`achievements:<char_id>`, like the quest manager) owns every achievement
+  row in memory — condition events walk the metadata index without touching
+  the database, new rows insert on creation, updates batch into a periodic
+  flush (and a flush on disconnect). Trophy counts live on the manager and
+  sync onto the character, grade completions notify quest conditions, stat
+  point and emote rewards apply on rank-up while item and title rewards wait
+  for the claim, and `Context.Achievements` shrank to pure persistence
 - Character-owned inventory manager: `Managers.Inventory`
   (`inventories:<char_id>`, like the quest manager) owns every item row and
   tab size of a character in memory — reads from memory, write-through

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -421,7 +421,8 @@ combat-heavy characters from accumulating document copies.
   row in memory — condition events walk the metadata index without touching
   the database, new rows insert on creation, updates batch into a periodic
   flush (and a flush on disconnect). Trophy counts live on the manager and
-  sync onto the character, grade completions notify quest conditions, stat
+  are read from it — the character struct keeps no mirrored copy — grade
+  completions notify quest conditions, stat
   point and emote rewards apply on rank-up while item and title rewards wait
   for the claim, and `Context.Achievements` shrank to pure persistence.
   Meta-trophies that track other achievements (`revise_achieve_*`,

--- a/lib/ms2ex/context/achievements.ex
+++ b/lib/ms2ex/context/achievements.ex
@@ -1,18 +1,11 @@
 defmodule Ms2ex.Context.Achievements do
-  alias Ms2ex.Managers
-  alias Ms2ex.Managers.Quest.Conditions
-  alias Ms2ex.Packets
   alias Ms2ex.Repo
   alias Ms2ex.Schema
-  alias Ms2ex.Storage
 
   import Ecto.Query, only: [from: 2]
 
-  def all(owner_id),
+  def list(owner_id),
     do: Repo.all(from achievement in Schema.Achievement, where: achievement.owner_id == ^owner_id)
-
-  def get(owner_id, achievement_id),
-    do: Repo.get_by(Schema.Achievement, %{owner_id: owner_id, achievement_id: achievement_id})
 
   def create(attrs) do
     %Schema.Achievement{}
@@ -26,270 +19,19 @@ defmodule Ms2ex.Context.Achievements do
     |> Repo.update()
   end
 
-  def progress(
-        character,
-        condition_type,
-        count,
-        target_string,
-        target_long,
-        code_string,
-        code_long
-      ) do
-    Storage.Achievements.for_condition(condition_type)
-    |> Enum.each(
-      &progress_metadata(
-        &1,
-        character,
-        condition_type,
-        count,
-        target_string,
-        target_long,
-        code_string,
-        code_long
-      )
-    )
-  end
+  @save_fields [:current_grade, :reward_grade, :favorite, :counter, :grades]
 
-  def load(character) do
-    [character.account_id, character.id]
-    |> Enum.uniq()
-    |> Enum.flat_map(&all/1)
-    |> Enum.map(fn achievement ->
-      Map.put(achievement, :metadata, Storage.Achievements.get(achievement.achievement_id))
+  # Progress is applied in memory before it is flushed, so the in-memory row
+  # already carries the new values; the flush must write them regardless of
+  # the diff a plain cast would compute.
+  def save(achievement) do
+    achievement
+    |> Schema.Achievement.changeset(%{})
+    |> then(fn changeset ->
+      Enum.reduce(@save_fields, changeset, fn field, changeset ->
+        Ecto.Changeset.force_change(changeset, field, Map.get(achievement, field))
+      end)
     end)
-    |> then(fn achievements ->
-      Ms2ex.Net.SenderSession.push(character, Packets.Achievement.initialize())
-      Ms2ex.Net.SenderSession.push(character, Packets.Achievement.load(achievements))
-    end)
+    |> Repo.update()
   end
-
-  def trophy_counts(character) do
-    [character.account_id, character.id]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-    |> Enum.flat_map(&all/1)
-    |> Enum.reduce([0, 0, 0], fn achievement, counts ->
-      completed = map_size(achievement.grades)
-      index = achievement.category - 1
-
-      if index in 0..2 do
-        List.update_at(counts, index, &(&1 + completed))
-      else
-        counts
-      end
-    end)
-  end
-
-  def toggle_favorite(character, achievement_id, favorite) do
-    achievement = Enum.find_value([character.account_id, character.id], &get(&1, achievement_id))
-
-    with %Schema.Achievement{} = achievement <- achievement,
-         {:ok, updated} <- update(achievement, %{favorite: favorite}) do
-      Ms2ex.Net.SenderSession.push(character, Packets.Achievement.favorite(updated))
-    else
-      nil -> :ok
-      error -> error
-    end
-  end
-
-  def claim_reward(character, achievement_id) do
-    with {achievement, metadata} <- achievement_with_metadata(character, achievement_id),
-         {:ok, updated} <- claim_pending_rewards(character, achievement, metadata) do
-      Ms2ex.Net.SenderSession.push(
-        character,
-        Packets.Achievement.update(Map.put(updated, :metadata, metadata))
-      )
-    else
-      _ -> :ok
-    end
-  end
-
-  defp update_progress(character, metadata, count) do
-    owner_id = if metadata.account_wide, do: character.account_id, else: character.id
-    existing = get(owner_id, metadata.id)
-    achievement = existing || new_achievement(owner_id, metadata)
-    grade = active_grade(achievement, metadata)
-    counter = achievement.counter + count
-    grades = complete_grades(achievement.grades, metadata.grades, counter)
-    next_grade = next_grade(metadata.grades, grades, grade)
-
-    attrs = %{counter: counter, grades: grades, current_grade: next_grade}
-
-    case persist(existing, achievement, attrs) do
-      {:ok, updated} ->
-        refresh_trophy_counts(character, achievement, updated)
-
-        if updated.counter != achievement.counter do
-          Packets.Achievement.update(Map.put(updated, :metadata, metadata))
-          |> send_packet(character)
-        end
-
-      _ ->
-        :ok
-    end
-  end
-
-  defp progress_metadata(
-         metadata,
-         character,
-         condition_type,
-         count,
-         target_string,
-         target_long,
-         code_string,
-         code_long
-       ) do
-    case active_condition(metadata, character) do
-      nil ->
-        :ok
-
-      condition ->
-        if condition.type == condition_type and
-             Conditions.metadata_matches?(
-               condition,
-               target_string,
-               target_long,
-               code_string,
-               code_long
-             ),
-           do: update_progress(character, metadata, count)
-    end
-  end
-
-  defp achievement_with_metadata(character, achievement_id) do
-    metadata = Storage.Achievements.get(achievement_id)
-
-    achievement =
-      [character.account_id, character.id]
-      |> Enum.find_value(fn owner_id -> get(owner_id, achievement_id) end)
-
-    if achievement && metadata, do: {achievement, metadata}, else: nil
-  end
-
-  defp deliver_reward(_character, nil), do: :ok
-
-  defp deliver_reward(character, %{type: :item, code: item_id, value: amount, rank: rarity}) do
-    item = Ms2ex.Context.Items.init(item_id, %{amount: amount, rarity: rarity})
-
-    case Managers.Inventory.add_item(character, item) do
-      {:ok, {_status, inventory_item} = result} ->
-        Ms2ex.Net.SenderSession.push(character, Packets.InventoryItem.add_item(result, character))
-
-        Ms2ex.Net.SenderSession.push(
-          character,
-          Packets.InventoryItem.mark_item_new(inventory_item)
-        )
-
-        Managers.Quest.notify_item_acquired(character, inventory_item)
-
-        :ok
-
-      _ ->
-        :error
-    end
-  end
-
-  defp deliver_reward(character, %{type: :statpoint, value: amount}) do
-    case Managers.Character.call(character, {:add_stat_point, :trophy, amount}) do
-      {:ok, _character} -> :ok
-      _ -> :error
-    end
-  end
-
-  defp deliver_reward(character, %{type: :title, code: title_id}) do
-    title = Ecto.build_assoc(character, :titles, %{title_id: title_id})
-
-    case Repo.insert(title, on_conflict: :nothing) do
-      {:ok, _title} ->
-        Ms2ex.Net.SenderSession.push(character, Ms2ex.Packets.UserEnv.set_titles([title_id]))
-        :ok
-
-      _ ->
-        :error
-    end
-  end
-
-  defp deliver_reward(character, %{type: :dynamicaction, code: emote_id}) do
-    case Ms2ex.Context.Emotes.learn(character, emote_id) do
-      {:ok, _emote} ->
-        Ms2ex.Net.SenderSession.push(character, Packets.Emote.learn(emote_id))
-        :ok
-
-      # already known; the grade still counts as claimed
-      {:error, _changeset} ->
-        :ok
-    end
-  end
-
-  defp deliver_reward(_character, _reward), do: :ok
-
-  defp claim_pending_rewards(character, achievement, metadata) do
-    if achievement.reward_grade > achievement.current_grade do
-      {:ok, achievement}
-    else
-      reward = get_in(metadata, [:grades, Integer.to_string(achievement.reward_grade), :reward])
-
-      with :ok <- deliver_reward(character, reward),
-           {:ok, updated} <- update(achievement, %{reward_grade: achievement.reward_grade + 1}) do
-        claim_pending_rewards(character, updated, metadata)
-      end
-    end
-  end
-
-  defp active_condition(metadata, character) do
-    achievement =
-      get(if(metadata.account_wide, do: character.account_id, else: character.id), metadata.id)
-
-    grade = active_grade(achievement, metadata)
-    get_in(metadata, [:grades, Integer.to_string(grade), :condition])
-  end
-
-  defp new_achievement(owner_id, metadata) do
-    grade = metadata.grades |> Map.keys() |> Enum.map(&String.to_integer/1) |> Enum.min()
-
-    %Schema.Achievement{
-      owner_id: owner_id,
-      achievement_id: metadata.id,
-      current_grade: grade,
-      reward_grade: grade,
-      category: metadata.category,
-      grades: %{}
-    }
-  end
-
-  defp active_grade(nil, metadata), do: new_achievement(0, metadata).current_grade
-  defp active_grade(achievement, _metadata), do: achievement.current_grade
-
-  defp complete_grades(grades, metadata_grades, counter) do
-    Enum.reduce(metadata_grades, grades, fn {grade, %{condition: %{value: value}}}, result ->
-      if counter >= value,
-        do: Map.put_new(result, grade, System.system_time(:second)),
-        else: result
-    end)
-  end
-
-  defp next_grade(metadata_grades, grades, current_grade) do
-    metadata_grades
-    |> Map.keys()
-    |> Enum.map(&String.to_integer/1)
-    |> Enum.sort()
-    |> Enum.find(current_grade, &(not Map.has_key?(grades, Integer.to_string(&1))))
-  end
-
-  defp persist(nil, achievement, attrs),
-    do: create(Map.merge(Map.from_struct(achievement), attrs))
-
-  defp persist(_existing, achievement, attrs), do: update(achievement, attrs)
-
-  defp refresh_trophy_counts(_character, previous, updated)
-       when map_size(updated.grades) == map_size(previous.grades),
-       do: :ok
-
-  defp refresh_trophy_counts(character, _previous, _updated) do
-    character = %{character | trophies: trophy_counts(character)}
-    Managers.Character.call(character, {:update, character})
-  end
-
-  defp send_packet(_packet, %{session_pid: nil}), do: :ok
-  defp send_packet(packet, character), do: Ms2ex.Net.SenderSession.push(character, packet)
 end

--- a/lib/ms2ex/context/character_stats.ex
+++ b/lib/ms2ex/context/character_stats.ex
@@ -3,8 +3,8 @@ defmodule Ms2ex.Context.CharacterStats do
   alias Ms2ex.Context.StatPoints
   alias Ms2ex.Schema
 
-  def apply(%Schema.Character{} = character) do
-    {character, equipment_stats} = ItemStats.apply(character)
+  def apply(%Schema.Character{} = character, equips) do
+    {character, equipment_stats} = ItemStats.apply(character, equips)
     {StatPoints.apply(character), equipment_stats}
   end
 end

--- a/lib/ms2ex/context/characters.ex
+++ b/lib/ms2ex/context/characters.ex
@@ -84,6 +84,12 @@ defmodule Ms2ex.Context.Characters do
     |> Repo.all()
   end
 
+  def learn_title(%Schema.Character{} = character, title_id) do
+    character
+    |> Ecto.build_assoc(:titles, %{title_id: title_id})
+    |> Repo.insert(on_conflict: :nothing)
+  end
+
   def maybe_discover_map(%Schema.Character{discovered_maps: maps} = character, new_map) do
     if Enum.member?(maps, new_map) do
       character

--- a/lib/ms2ex/context/item_stats.ex
+++ b/lib/ms2ex/context/item_stats.ex
@@ -18,10 +18,17 @@ defmodule Ms2ex.Context.ItemStats do
   @empty_stat_groups %{values: %{}, rates: %{}, special_values: %{}, special_rates: %{}}
 
   @doc """
-  Rebuilds a character's stats and returns the derived packet data.
+  Rebuilds a character's stats and returns the derived packet data. The
+  equipped items are passed in by the caller — contexts do not read manager
+  state.
   """
-  def apply(%Schema.Character{} = character) do
-    equips = equipped_gear(character)
+  def apply(%Schema.Character{} = character, equips) do
+    # metadata is not cached on the items; it is read from the storage cache
+    # while the stats are rebuilt
+    equips =
+      equips
+      |> Enum.filter(&(&1.inventory_tab == :gear))
+      |> Enum.map(&Context.Items.load_metadata(&1))
 
     stat_groups =
       Enum.reduce(equips, @empty_stat_groups, fn item, stat_groups ->
@@ -199,14 +206,6 @@ defmodule Ms2ex.Context.ItemStats do
     Map.merge(left, right, fn _group, left_values, right_values ->
       merge_values(left_values, right_values)
     end)
-  end
-
-  defp equipped_gear(character) do
-    # metadata is not cached on the character; it is read from the storage
-    # cache while the stats are rebuilt
-    character.equips
-    |> Enum.filter(&(&1.inventory_tab == :gear))
-    |> Enum.map(&Context.Items.load_metadata(&1))
   end
 
   defp calculate_gear_score(equips) do

--- a/lib/ms2ex/context/quests.ex
+++ b/lib/ms2ex/context/quests.ex
@@ -64,6 +64,20 @@ defmodule Ms2ex.Context.Quests do
     :ok
   end
 
+  @doc "Drops every persisted row of the given quests in one statement."
+  @spec delete_quests(integer(), [integer()], boolean()) :: :ok
+  def delete_quests(owner_id, quest_ids, account_quest?) do
+    CharacterQuest
+    |> where(
+      [quest],
+      quest.owner_id == ^owner_id and quest.quest_id in ^quest_ids and
+        quest.is_account_quest == ^account_quest?
+    )
+    |> Repo.delete_all()
+
+    :ok
+  end
+
   @spec has_completed_quest?(Character.t(), integer()) :: boolean()
   def has_completed_quest?(character, quest_id) do
     case Storage.Quests.get_meta(quest_id) do

--- a/lib/ms2ex/handlers/game/achievement.ex
+++ b/lib/ms2ex/handlers/game/achievement.ex
@@ -1,5 +1,4 @@
 defmodule Ms2ex.GameHandlers.Achievement do
-  alias Ms2ex.Context
   alias Ms2ex.Managers
 
   import Ms2ex.Packets.PacketReader
@@ -15,13 +14,13 @@ defmodule Ms2ex.GameHandlers.Achievement do
 
   defp handle_command(@claim_reward, packet, character) do
     {achievement_id, _packet} = get_int(packet)
-    Context.Achievements.claim_reward(character, achievement_id)
+    Managers.Achievement.claim_reward(character, achievement_id)
   end
 
   defp handle_command(@toggle_favorite, packet, character) do
     {achievement_id, packet} = get_int(packet)
     {favorite, _packet} = get_bool(packet)
-    Context.Achievements.toggle_favorite(character, achievement_id, favorite)
+    Managers.Achievement.toggle_favorite(character, achievement_id, favorite)
   end
 
   defp handle_command(_command, _packet, _character), do: :ok

--- a/lib/ms2ex/handlers/game/helpers/session.ex
+++ b/lib/ms2ex/handlers/game/helpers/session.ex
@@ -23,6 +23,7 @@ defmodule Ms2ex.GameHandlers.Helper.Session do
     character = %{character | online?: false}
     Managers.Inventory.stop(character)
     Managers.Quest.stop(character.id)
+    Managers.Achievement.stop(character)
     Context.Field.leave(character)
     notify_party_presence(character)
     notify_friend_presence(character)

--- a/lib/ms2ex/handlers/game/insignia.ex
+++ b/lib/ms2ex/handlers/game/insignia.ex
@@ -41,7 +41,10 @@ defmodule Ms2ex.GameHandlers.Insignia do
   end
 
   defp can_equip_insignia?(character, %{type: :trophy_point}, _insignia_id) do
-    Enum.sum(character.trophies) >= 1000
+    case Managers.Achievement.trophy_counts(character) do
+      [combat, adventure, lifestyle] -> combat + adventure + lifestyle >= 1000
+      _ -> false
+    end
   end
 
   defp can_equip_insignia?(character, %{type: :title, title_id: title_id}, _insignia_id) do

--- a/lib/ms2ex/handlers/game/response_key.ex
+++ b/lib/ms2ex/handlers/game/response_key.ex
@@ -35,7 +35,6 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
 
       character =
         character
-        |> Map.put(:equips, Managers.Inventory.list_equips(character))
         |> Context.Characters.preload([:friends, :stats])
         |> Context.Characters.load_skills()
 

--- a/lib/ms2ex/handlers/game/response_key.ex
+++ b/lib/ms2ex/handlers/game/response_key.ex
@@ -52,7 +52,9 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
           character
         end
 
-      character = %{character | trophies: Context.Achievements.trophy_counts(character)}
+      :ok = Managers.Achievement.start(character)
+
+      character = %{character | trophies: Managers.Achievement.trophy_counts(character)}
 
       Managers.Character.start(character)
       Managers.Character.call(character, :monitor)
@@ -112,7 +114,7 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
   end
 
   defp push_achievements(session, character) do
-    Context.Achievements.load(character)
+    Managers.Achievement.load(character)
     session
   end
 

--- a/lib/ms2ex/handlers/game/response_key.ex
+++ b/lib/ms2ex/handlers/game/response_key.ex
@@ -54,8 +54,6 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
 
       :ok = Managers.Achievement.start(character)
 
-      character = %{character | trophies: Managers.Achievement.trophy_counts(character)}
-
       Managers.Character.start(character)
       Managers.Character.call(character, :monitor)
 

--- a/lib/ms2ex/managers/achievement.ex
+++ b/lib/ms2ex/managers/achievement.ex
@@ -195,13 +195,9 @@ defmodule Ms2ex.Managers.Achievement do
       code_long: code_long
     }
 
-    {state, trophies_changed?} =
+    state =
       Storage.Achievements.for_condition(type)
-      |> Enum.reduce({state, false}, &progress(&1, event, character, &2))
-
-    if trophies_changed? do
-      Managers.Character.call(state.character_id, {:update_trophies, state.trophies})
-    end
+      |> Enum.reduce(state, &progress(&1, event, character, &2))
 
     {:noreply, state}
   end
@@ -219,11 +215,11 @@ defmodule Ms2ex.Managers.Achievement do
 
   # ---- progress ----
 
-  defp progress(metadata, event, character, {state, trophies_changed?}) do
+  defp progress(metadata, event, character, state) do
     if matches?(metadata, Map.get(state.achievements, metadata.id), event) do
-      advance(metadata, event, character, state, trophies_changed?)
+      advance(metadata, event, character, state)
     else
-      {state, trophies_changed?}
+      state
     end
   end
 
@@ -243,7 +239,7 @@ defmodule Ms2ex.Managers.Achievement do
     end
   end
 
-  defp advance(metadata, event, character, state, trophies_changed?) do
+  defp advance(metadata, event, character, state) do
     case ensure_achievement(metadata, state) do
       {:ok, achievement, state} ->
         {achievement, ranked_up?, trophies} =
@@ -254,10 +250,10 @@ defmodule Ms2ex.Managers.Achievement do
         unless ranked_up?,
           do: maybe_push_update(character, achievement, metadata)
 
-        {state, trophies_changed? or ranked_up?}
+        state
 
       :error ->
-        {state, trophies_changed?}
+        state
     end
   end
 

--- a/lib/ms2ex/managers/achievement.ex
+++ b/lib/ms2ex/managers/achievement.ex
@@ -1,0 +1,508 @@
+defmodule Ms2ex.Managers.Achievement do
+  use GenServer
+  use Ms2ex.Managers.Managed, prefix: "achievements", key: :character_id
+
+  alias Ms2ex.Context
+  alias Ms2ex.Managers
+  alias Ms2ex.Managers.Quest.Conditions
+  alias Ms2ex.Packets
+  alias Ms2ex.Schema
+  alias Ms2ex.Storage
+
+  import Ms2ex.Net.SenderSession, only: [push: 2]
+
+  @load_batch_size 60
+  @flush_interval :timer.minutes(1)
+
+  # The achievement manager keeps every achievement row of a character (and
+  # of its account) in memory: condition checks walk the storage index and
+  # never touch the database, new rows are inserted the moment they are
+  # created, and updates to existing rows are batched and flushed
+  # periodically and on disconnect. Rows are kept without their metadata
+  # documents; metadata is read from the storage cache at point of use.
+
+  def start(%Schema.Character{id: id} = character) do
+    case GenServer.start(__MODULE__, character, name: process_name(id)) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      error -> error
+    end
+  end
+
+  def stop(%Schema.Character{id: id}), do: stop(id)
+
+  def stop(id) when is_integer(id) do
+    case Process.whereis(process_name(id)) do
+      nil -> :ok
+      pid -> GenServer.stop(pid)
+    end
+  end
+
+  # ---- client API ----
+
+  @doc """
+  Sends the achievement initialize and load packets, batched per
+  #{@load_batch_size} entries.
+  """
+  def load(%Schema.Character{id: id}), do: call(id, :load)
+
+  @doc """
+  Advances every achievement whose active grade condition matches the
+  event. Fire-and-forget: progress is applied asynchronously.
+  """
+  def update(
+        character_id,
+        condition_type,
+        counter \\ 1,
+        target_string \\ "",
+        target_long \\ 0,
+        code_string \\ "",
+        code_long \\ 0
+      )
+
+  def update(
+        character_id,
+        condition_type,
+        counter,
+        target_string,
+        target_long,
+        code_string,
+        code_long
+      ) do
+    cast(
+      character_id,
+      {:update, condition_type, counter, target_string, target_long, code_string, code_long}
+    )
+  end
+
+  @doc "Trophy counts per category: [combat, adventure, lifestyle]."
+  def trophy_counts(%Schema.Character{id: id}), do: call(id, :trophy_counts)
+
+  @doc "Persists every pending achievement update."
+  def flush(%Schema.Character{id: id}), do: call(id, :flush)
+
+  @doc "Claims every pending reward grade up to the current grade."
+  def claim_reward(%Schema.Character{id: id}, achievement_id),
+    do: call(id, {:claim_reward, achievement_id})
+
+  def toggle_favorite(%Schema.Character{id: id}, achievement_id, favorite),
+    do: call(id, {:toggle_favorite, achievement_id, favorite})
+
+  # ---- Server Callbacks ----
+
+  @impl true
+  def init(%Schema.Character{} = character) do
+    achievements =
+      [character.account_id, character.id]
+      |> Enum.uniq()
+      |> Enum.reject(&is_nil/1)
+      |> Enum.flat_map(&Context.Achievements.list/1)
+      |> Map.new(&{&1.achievement_id, &1})
+
+    state = %{
+      character_id: character.id,
+      account_id: character.account_id,
+      achievements: achievements,
+      trophies: count_trophies(achievements),
+      dirty: MapSet.new()
+    }
+
+    Process.send_after(self(), :flush, @flush_interval)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:load, _from, state) do
+    {:ok, character} = Managers.Character.lookup(state.character_id)
+
+    if character.session_pid do
+      push(character, Packets.Achievement.initialize())
+
+      state.achievements
+      |> Map.values()
+      |> Enum.sort_by(& &1.achievement_id)
+      |> Enum.map(&Map.put(&1, :metadata, Storage.Achievements.get(&1.achievement_id)))
+      |> Enum.reject(&is_nil(&1.metadata))
+      |> Enum.chunk_every(@load_batch_size)
+      |> Enum.each(&push(character, Packets.Achievement.load(&1)))
+    end
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call(:trophy_counts, _from, state), do: {:reply, state.trophies, state}
+
+  @impl true
+  def handle_call(:flush, _from, state), do: {:reply, :ok, flush_dirty(state)}
+
+  @impl true
+  def handle_call({:claim_reward, achievement_id}, _from, state) do
+    {:ok, character} = Managers.Character.lookup(state.character_id)
+    metadata = Storage.Achievements.get(achievement_id)
+
+    state =
+      with {:ok, achievement} <- fetch(state, achievement_id),
+           false <- is_nil(metadata) do
+        achievement =
+          Enum.reduce(
+            achievement.reward_grade..achievement.current_grade//1,
+            achievement,
+            fn _grade, achievement ->
+              {:ok, achievement} = give_reward(achievement, metadata, character, true)
+              maybe_push_update(character, achievement, metadata)
+              achievement
+            end
+          )
+
+        put_achievement(state, achievement)
+      else
+        _ -> state
+      end
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:toggle_favorite, achievement_id, favorite}, _from, state) do
+    {:ok, character} = Managers.Character.lookup(state.character_id)
+
+    state =
+      with {:ok, achievement} <- fetch(state, achievement_id),
+           {:ok, updated} <- Context.Achievements.update(achievement, %{favorite: favorite}) do
+        maybe_push(character, Packets.Achievement.favorite(updated))
+        put_achievement(state, updated)
+      else
+        _ -> state
+      end
+
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_cast(
+        {:update, type, count, target_string, target_long, code_string, code_long},
+        state
+      ) do
+    {:ok, character} = Managers.Character.lookup(state.character_id)
+
+    event = %{
+      type: type,
+      count: count,
+      target_string: target_string,
+      target_long: target_long,
+      code_string: code_string,
+      code_long: code_long
+    }
+
+    {state, trophies_changed?} =
+      Storage.Achievements.for_condition(type)
+      |> Enum.reduce({state, false}, &progress(&1, event, character, &2))
+
+    if trophies_changed? do
+      Managers.Character.call(state.character_id, {:update_trophies, state.trophies})
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info(:flush, state) do
+    Process.send_after(self(), :flush, @flush_interval)
+    {:noreply, flush_dirty(state)}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    flush_dirty(state)
+  end
+
+  # ---- progress ----
+
+  defp progress(metadata, event, character, {state, trophies_changed?}) do
+    if matches?(metadata, Map.get(state.achievements, metadata.id), event) do
+      advance(metadata, event, character, state, trophies_changed?)
+    else
+      {state, trophies_changed?}
+    end
+  end
+
+  defp matches?(metadata, achievement, %{type: type} = event) do
+    case active_condition(metadata, achievement) do
+      %{type: ^type} = condition ->
+        Conditions.metadata_matches?(
+          condition,
+          event.target_string,
+          event.target_long,
+          event.code_string,
+          event.code_long
+        )
+
+      _ ->
+        false
+    end
+  end
+
+  defp advance(metadata, event, character, state, trophies_changed?) do
+    case ensure_achievement(metadata, state) do
+      {:ok, achievement, state} ->
+        {achievement, ranked_up?, trophies} =
+          rank_up(metadata, achievement, state.trophies, character, event.type, event.count)
+
+        state = %{state | trophies: trophies} |> put_achievement(achievement)
+
+        unless ranked_up?,
+          do: maybe_push_update(character, achievement, metadata)
+
+        {state, trophies_changed? or ranked_up?}
+
+      :error ->
+        {state, trophies_changed?}
+    end
+  end
+
+  defp active_condition(metadata, nil),
+    do: get_in(metadata, [:grades, Integer.to_string(lowest_grade(metadata)), :condition])
+
+  defp active_condition(metadata, achievement),
+    do: get_in(metadata, [:grades, Integer.to_string(achievement.current_grade), :condition])
+
+  # a matching event creates the row immediately; later progress only
+  # touches memory until the next flush
+  defp ensure_achievement(metadata, %{achievements: achievements} = state) do
+    case Map.get(achievements, metadata.id) do
+      %Schema.Achievement{} = achievement ->
+        {:ok, achievement, state}
+
+      nil ->
+        grade = lowest_grade(metadata)
+
+        attrs = %{
+          owner_id: owner_id(state, metadata),
+          achievement_id: metadata.id,
+          current_grade: grade,
+          reward_grade: grade,
+          category: metadata.category,
+          grades: %{}
+        }
+
+        case Context.Achievements.create(attrs) do
+          {:ok, achievement} -> {:ok, achievement, state}
+          error -> error
+        end
+    end
+  end
+
+  defp rank_up(metadata, achievement, trophies, character, condition_type, count) do
+    counter = counter_for(achievement, condition_type, count)
+    achievement = %{achievement | counter: counter}
+    walk_grades(metadata, achievement, trophies, character, false)
+  end
+
+  # gear score trophies track a maximum, every other condition accumulates
+  defp counter_for(achievement, :item_gear_score, count), do: max(achievement.counter, count)
+  defp counter_for(achievement, _condition_type, count), do: achievement.counter + count
+
+  defp walk_grades(metadata, achievement, trophies, character, ranked_up?) do
+    grade = get_in(metadata, [:grades, Integer.to_string(achievement.current_grade)])
+
+    cond do
+      grade == nil or achievement.counter < grade.condition.value ->
+        {achievement, ranked_up?, trophies}
+
+      map_size(achievement.grades) >= map_size(metadata.grades) ->
+        {achievement, ranked_up?, trophies}
+
+      true ->
+        now = System.system_time(:second)
+        grades = Map.put(achievement.grades, Integer.to_string(achievement.current_grade), now)
+        completed? = map_size(grades) >= map_size(metadata.grades)
+
+        achievement = %{
+          achievement
+          | grades: grades,
+            current_grade:
+              if(completed?,
+                do: achievement.current_grade,
+                else: achievement.current_grade + 1
+              )
+        }
+
+        trophies = bump_trophies(trophies, achievement.category)
+
+        {:ok, achievement} = give_reward(achievement, metadata, character, false)
+        maybe_push_update(character, achievement, metadata)
+
+        notify_quest_conditions(character.id, achievement)
+
+        walk_grades(metadata, achievement, trophies, character, true)
+    end
+  end
+
+  # grade completions feed back into quest conditions tracking other
+  # achievements' progress
+  defp notify_quest_conditions(character_id, achievement) do
+    Enum.each(
+      [:revise_achieve_multi_grade, :revise_achieve_single_grade, :hero_achieve],
+      &Managers.Quest.update_conditions(
+        character_id,
+        &1,
+        1,
+        "",
+        achievement.current_grade,
+        "",
+        achievement.achievement_id
+      )
+    )
+  end
+
+  defp bump_trophies(trophies, category) when category in 1..3,
+    do: List.update_at(trophies, category - 1, &(&1 + 1))
+
+  defp bump_trophies(trophies, _category), do: trophies
+
+  # ---- rewards ----
+
+  # Rewards that need no player interaction (stat points, emotes) are given
+  # as soon as the grade is awarded; item and title rewards wait for the
+  # player to claim them. Grades without a reward advance the reward grade
+  # so the trophy UI shows completion instead of a claim button.
+  defp give_reward(achievement, _metadata, _character, _manual?)
+       when achievement.reward_grade > achievement.current_grade,
+       do: {:ok, achievement}
+
+  defp give_reward(achievement, metadata, character, manual?) do
+    grade = get_in(metadata, [:grades, Integer.to_string(achievement.reward_grade)])
+    reward = grade && grade[:reward]
+    more_grades? = map_size(metadata.grades) > achievement.current_grade
+
+    cond do
+      is_nil(reward) and more_grades? ->
+        {:ok,
+         %{
+           achievement
+           | reward_grade: min(achievement.reward_grade + 1, achievement.current_grade)
+         }}
+
+      is_nil(reward) ->
+        {:ok, %{achievement | reward_grade: achievement.reward_grade + 1}}
+
+      true ->
+        deliver_reward(reward, achievement, character, manual?)
+    end
+  end
+
+  defp deliver_reward(%{type: :item} = reward, achievement, character, true) do
+    item = Context.Items.init(reward.code, %{amount: reward.value, rarity: reward.rank})
+
+    case Managers.Inventory.add_item(character, item) do
+      {:ok, {_status, inventory_item} = result} ->
+        push(character, Packets.InventoryItem.add_item(result, character))
+        push(character, Packets.InventoryItem.mark_item_new(inventory_item))
+        Managers.Quest.notify_item_acquired(character, inventory_item)
+        {:ok, %{achievement | reward_grade: achievement.reward_grade + 1}}
+
+      _ ->
+        {:error, :inventory_full}
+    end
+  end
+
+  defp deliver_reward(%{type: :title} = reward, achievement, character, true) do
+    case Context.Characters.learn_title(character, reward.code) do
+      {:ok, title} ->
+        push(character, Packets.UserEnv.set_titles([title.title_id]))
+        {:ok, %{achievement | reward_grade: achievement.reward_grade + 1}}
+
+      _ ->
+        {:error, :title_failed}
+    end
+  end
+
+  defp deliver_reward(%{type: :statpoint} = reward, achievement, character, _manual?) do
+    case Managers.Character.call(character, {:add_stat_point, :trophy, reward.value}) do
+      {:ok, _character} -> {:ok, %{achievement | reward_grade: achievement.reward_grade + 1}}
+      :error -> {:error, :statpoint_failed}
+    end
+  end
+
+  defp deliver_reward(%{type: :dynamicaction} = reward, achievement, character, _manual?) do
+    case Context.Emotes.learn(character, reward.code) do
+      {:ok, _emote} ->
+        push(character, Packets.Emote.learn(reward.code))
+
+      # already known; the grade still counts as claimed
+      {:error, _changeset} ->
+        :ok
+    end
+
+    {:ok, %{achievement | reward_grade: achievement.reward_grade + 1}}
+  end
+
+  # TODO skill point rewards (the reference grants skill points with a
+  # rank-based breakdown); no skill point API exists yet, so the grade
+  # stays pending and can be claimed once support lands
+  defp deliver_reward(%{type: :skillpoint}, _achievement, _character, _manual?),
+    do: {:error, :skillpoint_unsupported}
+
+  # cosmetic unlock types only drive client-side visuals
+  defp deliver_reward(_reward, achievement, _character, _manual?),
+    do: {:ok, %{achievement | reward_grade: achievement.reward_grade + 1}}
+
+  # ---- state helpers ----
+
+  defp fetch(state, achievement_id) do
+    case Map.get(state.achievements, achievement_id) do
+      nil -> :error
+      achievement -> {:ok, achievement}
+    end
+  end
+
+  defp put_achievement(state, achievement) do
+    %{
+      state
+      | achievements: Map.put(state.achievements, achievement.achievement_id, achievement),
+        dirty: MapSet.put(state.dirty, achievement.achievement_id)
+    }
+  end
+
+  defp owner_id(state, metadata),
+    do: if(metadata.account_wide, do: state.account_id, else: state.character_id)
+
+  defp lowest_grade(metadata) do
+    metadata.grades |> Map.keys() |> Enum.map(&String.to_integer/1) |> Enum.min()
+  end
+
+  defp count_trophies(achievements) do
+    Enum.reduce(achievements, [0, 0, 0], fn {_id, achievement}, counts ->
+      index = achievement.category - 1
+
+      if index in 0..2 do
+        List.update_at(counts, index, &(&1 + map_size(achievement.grades)))
+      else
+        counts
+      end
+    end)
+  end
+
+  defp maybe_push_update(%{session_pid: nil}, _achievement, _metadata), do: :ok
+
+  defp maybe_push_update(character, achievement, metadata) do
+    push(character, Packets.Achievement.update(Map.put(achievement, :metadata, metadata)))
+  end
+
+  defp maybe_push(%{session_pid: nil}, _packet), do: :ok
+  defp maybe_push(character, packet), do: push(character, packet)
+
+  # ---- persistence ----
+
+  # rows are inserted when they are created, so flushing only ever updates
+  defp flush_dirty(state) do
+    Enum.each(state.dirty, fn achievement_id ->
+      with {:ok, achievement} <- fetch(state, achievement_id) do
+        Context.Achievements.save(achievement)
+      end
+    end)
+
+    %{state | dirty: MapSet.new()}
+  end
+end

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -119,6 +119,10 @@ defmodule Ms2ex.Managers.Character do
     {:reply, :ok, character}
   end
 
+  def handle_call({:update_trophies, trophies}, _from, character) do
+    {:reply, :ok, %{character | trophies: trophies}}
+  end
+
   # --------------------------------
   # Stat Points (AP)
   # --------------------------------

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -119,6 +119,11 @@ defmodule Ms2ex.Managers.Character do
     {:reply, :ok, character}
   end
 
+  # trophies are a virtual field serialized straight from character structs
+  # (friend lists include offline characters, where no achievement manager
+  # exists); the achievement manager owns the authoritative counts and is
+  # the single writer of this copy — same pattern as the equips copy, owned
+  # by the inventory manager
   def handle_call({:update_trophies, trophies}, _from, character) do
     {:reply, :ok, %{character | trophies: trophies}}
   end

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -119,15 +119,6 @@ defmodule Ms2ex.Managers.Character do
     {:reply, :ok, character}
   end
 
-  # trophies are a virtual field serialized straight from character structs
-  # (friend lists include offline characters, where no achievement manager
-  # exists); the achievement manager owns the authoritative counts and is
-  # the single writer of this copy — same pattern as the equips copy, owned
-  # by the inventory manager
-  def handle_call({:update_trophies, trophies}, _from, character) do
-    {:reply, :ok, %{character | trophies: trophies}}
-  end
-
   # --------------------------------
   # Stat Points (AP)
   # --------------------------------

--- a/lib/ms2ex/managers/character/equips.ex
+++ b/lib/ms2ex/managers/character/equips.ex
@@ -160,8 +160,9 @@ defmodule Ms2ex.Managers.Character.Equips do
       if :OH in item.metadata.slots, do: [equip_slot], else: item.metadata.slots
 
     conflicts =
-      Enum.filter(
-        character.equips,
+      character
+      |> Managers.Inventory.list_equips()
+      |> Enum.filter(
         &(&1.equip_slot in conflict_slots and &1.inventory_tab == item.inventory_tab)
       )
 
@@ -263,10 +264,10 @@ defmodule Ms2ex.Managers.Character.Equips do
   end
 
   defp refresh(character) do
-    equips = Managers.Inventory.list_equips(character)
-
-    %{character | equips: equips}
-    |> Context.CharacterStats.apply()
+    # equipped items live in the inventory manager; they are read here for
+    # the stat rebuild and never cached on the character
+    character
+    |> Context.CharacterStats.apply(Managers.Inventory.list_equips(character))
     |> elem(0)
   end
 end

--- a/lib/ms2ex/managers/character/experience.ex
+++ b/lib/ms2ex/managers/character/experience.ex
@@ -25,7 +25,8 @@ defmodule Ms2ex.Managers.Character.Experience do
 
   def refresh_level(character, old_level) do
     if old_level != character.level do
-      {character, _equipment_stats} = Context.CharacterStats.apply(character)
+      equips = Managers.Inventory.list_equips(character)
+      {character, _equipment_stats} = Context.CharacterStats.apply(character, equips)
       Context.Field.broadcast(character, Packets.LevelUp.bytes(character))
       Context.Field.broadcast_stats(character)
 

--- a/lib/ms2ex/managers/field/character.ex
+++ b/lib/ms2ex/managers/field/character.ex
@@ -10,7 +10,8 @@ defmodule Ms2ex.Managers.Field.Character do
 
   def add_character(character, state) do
     Logger.info("Field #{state.map_id} @ Channel #{state.channel_id}: #{character.name} joined")
-    {character, _equipment_stats} = Context.CharacterStats.apply(character)
+    equips = Managers.Inventory.list_equips(character)
+    {character, _equipment_stats} = Context.CharacterStats.apply(character, equips)
 
     # Load other characters
     for char_id <- Map.keys(state.sessions) do

--- a/lib/ms2ex/managers/quest.ex
+++ b/lib/ms2ex/managers/quest.ex
@@ -648,8 +648,8 @@ defmodule Ms2ex.Managers.Quest do
     # Get character for sending packets
     {:ok, character} = Managers.Character.lookup(state.character_id)
 
-    Context.Achievements.progress(
-      character,
+    Managers.Achievement.update(
+      state.character_id,
       condition_type,
       counter,
       target_string,

--- a/lib/ms2ex/managers/quest.ex
+++ b/lib/ms2ex/managers/quest.ex
@@ -308,15 +308,19 @@ defmodule Ms2ex.Managers.Quest do
 
   @impl true
   def handle_call({:expire_quests, quest_ids}, _from, state) do
-    {new_state, removed_ids} =
-      Enum.reduce(quest_ids, {state, []}, fn quest_id, {acc_state, removed} ->
+    {new_state, removed_ids, dropped} =
+      Enum.reduce(quest_ids, {state, [], []}, fn quest_id, {acc_state, removed, dropped} ->
         case expire_quest(quest_id, acc_state) do
-          {acc_state, quest_id} when is_integer(quest_id) -> {acc_state, [quest_id | removed]}
-          {acc_state, nil} -> {acc_state, removed}
+          {acc_state, quest} when is_map(quest) ->
+            {acc_state, [quest.quest_id | removed], [quest | dropped]}
+
+          {acc_state, nil} ->
+            {acc_state, removed, dropped}
         end
       end)
 
     removed_ids = Enum.reverse(removed_ids)
+    drop_rows(dropped, new_state)
 
     with {:ok, character} <- Managers.Character.lookup(state.character_id),
          true <- character.session_pid != nil do
@@ -911,8 +915,28 @@ defmodule Ms2ex.Managers.Quest do
         {state, nil}
 
       quest ->
-        Context.Quests.delete_quest(quest.owner_id, quest.quest_id, quest.is_account_quest)
-        {Managers.Quest.State.remove_quest_from_state(quest, state), quest_id}
+        {Managers.Quest.State.remove_quest_from_state(quest, state), quest}
+    end
+  end
+
+  # expired rows drop in one statement per owner scope
+  defp drop_rows(quests, state) do
+    {account_quests, character_quests} = Enum.split_with(quests, & &1.is_account_quest)
+
+    unless account_quests == [] do
+      Context.Quests.delete_quests(
+        state.account_id,
+        Enum.map(account_quests, & &1.quest_id),
+        true
+      )
+    end
+
+    unless character_quests == [] do
+      Context.Quests.delete_quests(
+        state.character_id,
+        Enum.map(character_quests, & &1.quest_id),
+        false
+      )
     end
   end
 

--- a/lib/ms2ex/managers/quest.ex
+++ b/lib/ms2ex/managers/quest.ex
@@ -16,6 +16,8 @@ defmodule Ms2ex.Managers.Quest do
   alias Ms2ex.Storage
   import Ms2ex.Net.SenderSession, only: [push: 2]
 
+  @flush_interval :timer.minutes(1)
+
   # Constants
   @batch_size 200
   @default_timeout 5000
@@ -201,9 +203,12 @@ defmodule Ms2ex.Managers.Quest do
     update_conditions(character.id, :item_exist, amount, "", 0, "", item.item_id)
   end
 
+  @doc "Persists every pending condition-counter change."
+  def flush(character_id), do: GenServer.call(process_name(character_id), :flush)
+
   @doc """
-  Stops the quest manager. Quest progress is written through on every
-  mutation, so a plain stop loses nothing.
+  Stops the quest manager. Quest transitions write through, and pending
+  condition-counter changes are flushed on stop, so nothing is lost.
   """
   def stop(character_id) do
     case Process.whereis(process_name(character_id)) do
@@ -225,9 +230,11 @@ defmodule Ms2ex.Managers.Quest do
       account_quests: account_quests,
       character_quests: character_quests,
       character_id: character.id,
-      account_id: character.account_id
+      account_id: character.account_id,
+      dirty: MapSet.new()
     }
 
+    Process.send_after(self(), :flush, @flush_interval)
     {:ok, initialize_auto_start_quests(character, state)}
   end
 
@@ -245,6 +252,9 @@ defmodule Ms2ex.Managers.Quest do
     quest = Managers.Quest.State.get_quest_from_state(quest_id, state)
     {:reply, quest, state}
   end
+
+  @impl true
+  def handle_call(:flush, _from, state), do: {:reply, :ok, flush_dirty(state)}
 
   @impl true
   def handle_call({:start_quest, quest_metadata, character}, _from, state) do
@@ -658,111 +668,99 @@ defmodule Ms2ex.Managers.Quest do
       code_long
     )
 
-    # Process character and account quests
-    {updated_character_quests, character_updated} =
-      update_quest_conditions(
-        state.character_quests,
-        character,
-        condition_type,
-        counter,
-        target_string,
-        target_long,
-        code_string,
-        code_long
-      )
+    # Process character and account quests; condition counters accumulate
+    # in memory and mark quests dirty for the periodic flush
+    event = %{
+      type: condition_type,
+      count: counter,
+      target_string: target_string,
+      target_long: target_long,
+      code_string: code_string,
+      code_long: code_long
+    }
 
-    {updated_account_quests, account_updated} =
-      update_quest_conditions(
-        state.account_quests,
-        character,
-        condition_type,
-        counter,
-        target_string,
-        target_long,
-        code_string,
-        code_long
-      )
+    {updated_character_quests, dirty, character_updated} =
+      update_quest_conditions(state.character_quests, character, event, state.dirty)
 
-    # Only update state if any quests were actually updated
+    {updated_account_quests, dirty, account_updated} =
+      update_quest_conditions(state.account_quests, character, event, dirty)
+
     if character_updated || account_updated do
-      new_state = %{
-        state
-        | character_quests: updated_character_quests,
-          account_quests: updated_account_quests
-      }
-
-      {:noreply, new_state}
+      {:noreply,
+       %{
+         state
+         | character_quests: updated_character_quests,
+           account_quests: updated_account_quests,
+           dirty: dirty
+       }}
     else
       {:noreply, state}
     end
   end
 
-  # Helper function to update conditions for a set of quests
-  defp update_quest_conditions(
-         quests,
-         character,
-         condition_type,
-         counter,
-         target_string,
-         target_long,
-         code_string,
-         code_long
-       ) do
-    Enum.reduce(quests, {quests, false}, fn {quest_id, quest}, {acc_quests, any_updated} ->
-      case update_single_quest_condition(
-             quest,
-             character,
-             condition_type,
-             counter,
-             target_string,
-             target_long,
-             code_string,
-             code_long
-           ) do
-        {:updated, updated_quest} ->
-          {Map.put(acc_quests, quest_id, updated_quest), true}
+  @impl true
+  def handle_info(:flush, state) do
+    Process.send_after(self(), :flush, @flush_interval)
+    {:noreply, flush_dirty(state)}
+  end
 
-        :unchanged ->
-          {acc_quests, any_updated}
+  @impl true
+  def terminate(_reason, state) do
+    flush_dirty(state)
+  end
+
+  # Quest transitions that own their persistence (start, complete, abandon,
+  # expire) keep writing through; condition counters accumulate in memory
+  # and batch into the periodic flush below, so ordinary gameplay events
+  # never touch the database.
+  defp flush_dirty(state) do
+    state.dirty
+    |> Enum.reduce(state, fn quest_id, state ->
+      case Managers.Quest.State.get_quest_from_state(quest_id, state) do
+        nil ->
+          state
+
+        quest ->
+          Context.Quests.update_quest(quest, %{conditions: quest.conditions})
+          %{state | dirty: MapSet.delete(state.dirty, quest_id)}
       end
     end)
   end
 
-  defp update_single_quest_condition(
-         quest,
-         character,
-         condition_type,
-         counter,
-         target_string,
-         target_long,
-         code_string,
-         code_long
-       ) do
+  # Helper function to update conditions for a set of quests. Condition
+  # counters only touch memory here; the quest is marked dirty for the
+  # periodic flush instead of being written back per event.
+  defp update_quest_conditions(quests, character, event, dirty) do
+    Enum.reduce(quests, {quests, dirty, false}, fn {quest_id, quest},
+                                                   {acc_quests, dirty, any_updated} ->
+      case update_single_quest_condition(quest, character, event) do
+        {:updated, updated_quest} ->
+          {Map.put(acc_quests, quest_id, updated_quest), MapSet.put(dirty, quest_id), true}
+
+        :unchanged ->
+          {acc_quests, dirty, any_updated}
+      end
+    end)
+  end
+
+  defp update_single_quest_condition(quest, character, event) do
     updated_quest =
       Managers.Quest.Conditions.update(
         quest,
-        condition_type,
-        counter,
-        target_string,
-        target_long,
-        code_string,
-        code_long
+        event.type,
+        event.count,
+        event.target_string,
+        event.target_long,
+        event.code_string,
+        event.code_long
       )
 
     if updated_quest == quest do
       :unchanged
     else
-      case Context.Quests.update_quest(updated_quest, %{conditions: updated_quest.conditions}) do
-        {:ok, persisted_quest} ->
-          maybe_push_condition_update(character, quest, persisted_quest, condition_type)
-          handle_auto_completion(persisted_quest, character.id)
-          {:updated, persisted_quest}
-
-        {:error, _changeset} ->
-          # keep gameplay moving on the in-memory state even if the write fails
-          maybe_push_condition_update(character, quest, updated_quest, condition_type)
-          {:updated, updated_quest}
-      end
+      maybe_push_condition_update(character, quest, updated_quest, event.type)
+      handle_auto_completion(updated_quest, character.id)
+      {:updated, updated_quest}
     end
   end
 

--- a/lib/ms2ex/managers/quest/conditions.ex
+++ b/lib/ms2ex/managers/quest/conditions.ex
@@ -46,7 +46,14 @@ defmodule Ms2ex.Managers.Quest.Conditions do
     :skill,
     :stay_cube,
     :stay_map,
-    :talk_in
+    :talk_in,
+    # meta-trophies tracking other achievements: the pushed code is the
+    # completing achievement id; without the gate every grade completion
+    # counts into every meta-trophy
+    :revise_achieve_multi_grade,
+    :revise_achieve_single_grade,
+    :hero_achieve,
+    :hero_achieve_grade
   ]
 
   # condition types whose target parameter acts as a minimum-value gate: the
@@ -64,7 +71,18 @@ defmodule Ms2ex.Managers.Quest.Conditions do
 
   # condition types whose target integers enumerate allowed values (e.g. map
   # ids) that the pushed value must match exactly
-  @target_equality_types [:chat, :emotion, :holdtime, :laddertime, :ropetime]
+  @target_equality_types [
+    :chat,
+    :emotion,
+    :holdtime,
+    :laddertime,
+    :ropetime,
+    # the pushed target is the achieved grade of the tracked trophy
+    :revise_achieve_multi_grade,
+    :revise_achieve_single_grade,
+    :hero_achieve,
+    :hero_achieve_grade
+  ]
 
   def all_met?(quest) do
     Enum.all?(quest.conditions, fn {_idx, condition} ->

--- a/lib/ms2ex/managers/quest/requirements.ex
+++ b/lib/ms2ex/managers/quest/requirements.ex
@@ -37,11 +37,12 @@ defmodule Ms2ex.Managers.Quest.Requirements do
       check_event_tag(character, metadata.basic.event_tag)
   end
 
-  defp check_event_tag(_character, _event_tag) do
-    # TODO: Implement event tag checking when event system is available
-    # This should check if the event_tag is currently active in the game
-    # For now, return true to not block quest progression
-    true
+  defp check_event_tag(_character, event_tag) do
+    # event-tagged quests are only meant to start through a matching server
+    # event; without an event system no tag can ever be active, so they must
+    # never start on their own (stale event content would otherwise be
+    # auto-started and immediately expired by the client)
+    event_tag in [nil, ""]
   end
 
   defp meet_level_req?(character, req) do

--- a/lib/ms2ex/managers/quest/rewards.ex
+++ b/lib/ms2ex/managers/quest/rewards.ex
@@ -51,7 +51,10 @@ defmodule Ms2ex.Managers.Quest.Rewards do
 
         case Inventory.add_item(character, %{item | metadata: metadata}) do
           {:ok, result} ->
+            # the bare add result ({:create, item} / {:update, item}) is what
+            # post-commit delivery serializes into add-item packets
             Managers.Quest.notify_item_acquired(character, added_item(result))
+            result
 
           other ->
             Repo.rollback({:reward_item_failed, reward_item.id, other})

--- a/lib/ms2ex/packets/game/character_info.ex
+++ b/lib/ms2ex/packets/game/character_info.ex
@@ -1,4 +1,5 @@
 defmodule Ms2ex.Packets.CharacterInfo do
+  alias Ms2ex.Managers
   alias Ms2ex.Context
   alias Ms2ex.Enums
   alias Ms2ex.Packets
@@ -19,7 +20,8 @@ defmodule Ms2ex.Packets.CharacterInfo do
   def load(%Schema.Character{} = character) do
     # the character comes from the manager, so its equip list is already
     # current; only the derived stats need rebuilding
-    {character, equipment_stats} = Context.CharacterStats.apply(character)
+    equips = Managers.Inventory.list_equips(character)
+    {character, equipment_stats} = Context.CharacterStats.apply(character, equips)
 
     __MODULE__
     |> build()
@@ -118,7 +120,10 @@ defmodule Ms2ex.Packets.CharacterInfo do
   defp put_buffer(packet, buffer), do: put_int(packet, byte_size(buffer)) <> buffer
 
   defp equips(character) do
-    equips = Enum.filter(character.equips, &(&1.inventory_tab in [:gear, :outfit]))
+    equips =
+      character
+      |> Managers.Inventory.list_equips()
+      |> Enum.filter(&(&1.inventory_tab in [:gear, :outfit]))
 
     ""
     |> put_byte(length(equips))

--- a/lib/ms2ex/packets/game/field_add_user.ex
+++ b/lib/ms2ex/packets/game/field_add_user.ex
@@ -1,4 +1,5 @@
 defmodule Ms2ex.Packets.FieldAddUser do
+  alias Ms2ex.Managers
   alias Ms2ex.Enums
   alias Ms2ex.Packets
   alias Ms2ex.Schema
@@ -79,9 +80,11 @@ defmodule Ms2ex.Packets.FieldAddUser do
   end
 
   def appearance(character) do
+    equips = Managers.Inventory.list_equips(character)
+
     ""
-    |> put_byte(length(character.equips))
-    |> Packets.InventoryItem.put_equips(character.equips, character)
+    |> put_byte(length(equips))
+    |> Packets.InventoryItem.put_equips(equips, character)
     |> put_byte(0x1)
     |> put_long()
     |> put_long()

--- a/test/ms2ex/achievement_manager_test.exs
+++ b/test/ms2ex/achievement_manager_test.exs
@@ -1,0 +1,156 @@
+defmodule Ms2ex.AchievementManagerTest do
+  use Ms2ex.DataCase, async: false
+
+  alias Ms2ex.Context.Achievements
+  alias Ms2ex.Managers
+  alias Ms2ex.Repo
+  alias Ms2ex.Schema
+
+  import Ms2ex.TestHelpers
+
+  # counter-type achievement with two grades (values 2 and 4)
+  @achievement_id 236_000
+  @metadata %{
+    id: @achievement_id,
+    account_wide: false,
+    category: 2,
+    grades: %{
+      "1" => %{condition: %{type: :monster_kill, value: 2}},
+      "2" => %{condition: %{type: :monster_kill, value: 4}, reward: nil}
+    }
+  }
+  @reward_id 236_001
+  @reward_metadata %{
+    id: @reward_id,
+    account_wide: false,
+    category: 1,
+    grades: %{
+      "1" => %{
+        condition: %{type: :quest_accept, value: 1},
+        reward: %{type: :statpoint, value: 3}
+      }
+    }
+  }
+
+  setup {Mimic, :set_mimic_global}
+
+  setup do
+    stub_metadata(%{
+      "achievement:#{@achievement_id}" => @metadata,
+      "achievement:#{@reward_id}" => @reward_metadata,
+      "achievement:index" => %{
+        monster_kill: [@achievement_id],
+        quest_accept: [@reward_id]
+      }
+    })
+
+    account =
+      Repo.insert!(%Schema.Account{
+        username: "ach_test_#{System.unique_integer([:positive])}",
+        password_hash: "hash"
+      })
+
+    character =
+      Repo.insert!(%Schema.Character{
+        account_id: account.id,
+        name: "AchTest#{System.unique_integer([:positive])}",
+        map_id: 2_000_062,
+        job: :knight,
+        level: 1,
+        skin_color: {},
+        gender: :male,
+        discovered_maps: [],
+        insignia_id: 0,
+        online?: false,
+        position: %{x: 0, y: 0, z: 0, rotation: 0},
+        stat_point_allocation: %{},
+        stat_point_sources: Ms2ex.Types.AttributePointSource.default_sources()
+      })
+      |> Map.put(:session_pid, self())
+      |> Map.put(:sender_session_pid, self())
+
+    {:ok, char_pid} = Managers.Character.start(character)
+    :ok = Managers.Achievement.start(character)
+
+    achievement_pid = Process.whereis(:"achievements:#{character.id}")
+
+    on_exit(fn ->
+      if achievement_pid != nil and Process.alive?(achievement_pid),
+        do: GenServer.stop(achievement_pid)
+
+      if Process.alive?(char_pid), do: GenServer.stop(char_pid)
+    end)
+
+    # both managers read and write the database from their own processes
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), char_pid)
+    Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), achievement_pid)
+
+    %{character: character}
+  end
+
+  # progress is applied through asynchronous casts; poll until the
+  # assertion holds instead of sleeping a fixed amount
+  defp wait_until(fun, attempts \\ 50)
+  defp wait_until(fun, attempts) when attempts <= 0, do: fun.()
+
+  defp wait_until(fun, attempts) do
+    try do
+      fun.()
+    rescue
+      ExUnit.AssertionError ->
+        Process.sleep(20)
+        wait_until(fun, attempts - 1)
+    end
+  end
+
+  test "progress accumulates in memory and creates the row once", %{character: character} do
+    Managers.Achievement.update(character.id, :monster_kill)
+
+    # the row is created the moment progress starts, with its insert-time
+    # defaults; the accumulated counter only reaches the database on flush
+    wait_until(fn ->
+      assert length(Achievements.list(character.id)) == 1
+    end)
+
+    # a second event advances the counter in memory without another insert
+    Managers.Achievement.update(character.id, :monster_kill)
+    :ok = Managers.Achievement.flush(character)
+
+    assert [%Schema.Achievement{counter: 2}] = Achievements.list(character.id)
+  end
+
+  test "grade completion bumps trophy counts and stop flushes progress", %{
+    character: character
+  } do
+    Managers.Achievement.update(character.id, :monster_kill)
+    Managers.Achievement.update(character.id, :monster_kill)
+
+    wait_until(fn ->
+      assert Managers.Achievement.trophy_counts(character) == [0, 1, 0]
+    end)
+
+    # the pending grade completion persists on flush
+    :ok = Managers.Achievement.flush(character)
+
+    assert [%Schema.Achievement{counter: 2, current_grade: 2, grades: grades}] =
+             Achievements.list(character.id)
+
+    assert Map.keys(grades) == ["1"]
+  end
+
+  test "stat point rewards are granted automatically on rank up", %{character: character} do
+    Managers.Achievement.update(character.id, :quest_accept)
+
+    wait_until(fn ->
+      saved = Repo.reload(character)
+      assert saved.stat_point_sources.trophy == 3
+    end)
+
+    # the reward grade advanced past the current grade in memory, so
+    # nothing is left to claim
+    Managers.Achievement.claim_reward(character, @reward_id)
+    :ok = Managers.Achievement.flush(character)
+
+    assert [%Schema.Achievement{reward_grade: 2}] = Achievements.list(character.id)
+  end
+end

--- a/test/ms2ex/context_achievements_test.exs
+++ b/test/ms2ex/context_achievements_test.exs
@@ -4,13 +4,10 @@ defmodule Ms2ex.Context.AchievementsTest do
   alias Ms2ex.Context.Achievements
   alias Ms2ex.Schema
 
-  test "counts an owner once when account and character ids are equal" do
-    owner_id = 999_999
-    character = %Schema.Character{id: owner_id, account_id: owner_id}
-
+  test "lists achievements by owner" do
     {:ok, _achievement} =
       Achievements.create(%{
-        owner_id: owner_id,
+        owner_id: 999_998,
         achievement_id: 100,
         current_grade: 1,
         reward_grade: 1,
@@ -18,6 +15,27 @@ defmodule Ms2ex.Context.AchievementsTest do
         grades: %{"1" => 100}
       })
 
-    assert Achievements.trophy_counts(character) == [0, 1, 0]
+    assert [%Schema.Achievement{achievement_id: 100}] = Achievements.list(999_998)
+    assert [] = Achievements.list(999_999)
+  end
+
+  test "updates mutable fields of an achievement row" do
+    {:ok, achievement} =
+      Achievements.create(%{
+        owner_id: 999_998,
+        achievement_id: 101,
+        current_grade: 1,
+        reward_grade: 1,
+        category: 1,
+        counter: 0,
+        grades: %{}
+      })
+
+    {:ok, updated} =
+      Achievements.update(achievement, %{counter: 5, grades: %{"1" => 200}, favorite: true})
+
+    assert updated.counter == 5
+    assert updated.grades == %{"1" => 200}
+    assert updated.favorite
   end
 end

--- a/test/ms2ex/equip_flow_test.exs
+++ b/test/ms2ex/equip_flow_test.exs
@@ -119,5 +119,6 @@ defmodule Ms2ex.EquipFlowTest do
     item
   end
 
-  defp equip_summary(character), do: Enum.map(character.equips, & &1.item_id)
+  defp equip_summary(character),
+    do: character |> Managers.Inventory.list_equips() |> Enum.map(& &1.item_id)
 end

--- a/test/ms2ex/equips_test.exs
+++ b/test/ms2ex/equips_test.exs
@@ -332,5 +332,6 @@ defmodule Ms2ex.EquipsTest do
     })
   end
 
-  defp equips(character), do: Enum.map(character.equips, & &1.equip_slot)
+  defp equips(character),
+    do: character |> Managers.Inventory.list_equips() |> Enum.map(& &1.equip_slot)
 end

--- a/test/ms2ex/quest_manager_test.exs
+++ b/test/ms2ex/quest_manager_test.exs
@@ -1,0 +1,104 @@
+defmodule Ms2ex.QuestManagerTest do
+  use Ms2ex.DataCase, async: false
+
+  alias Ms2ex.Context.Quests
+  alias Ms2ex.Managers
+  alias Ms2ex.Repo
+  alias Ms2ex.Schema
+
+  import Ms2ex.TestHelpers
+
+  # a world quest with one map condition worth 2 visits
+  @quest_id 2_001_045
+  @quest_metadata %{
+    id: @quest_id,
+    basic: %{type: :world_quest},
+    conditions: [%{type: :map, value: 2, codes: %{range: nil, strings: [], integers: []}}]
+  }
+
+  setup {Mimic, :set_mimic_global}
+
+  setup do
+    stub_metadata(%{"quest:#{@quest_id}" => @quest_metadata})
+
+    account =
+      Repo.insert!(%Schema.Account{
+        username: "quest_test_#{System.unique_integer([:positive])}",
+        password_hash: "hash"
+      })
+
+    character =
+      Repo.insert!(%Schema.Character{
+        account_id: account.id,
+        name: "QuestTest#{System.unique_integer([:positive])}",
+        map_id: 2_000_062,
+        job: :knight,
+        level: 1,
+        skin_color: {},
+        gender: :male,
+        stat_point_allocation: %{},
+        stat_point_sources: Ms2ex.Types.AttributePointSource.default_sources()
+      })
+      |> Map.put(:session_pid, self())
+      |> Map.put(:sender_session_pid, self())
+
+    {:ok, _quest} =
+      Quests.create_quest(%{
+        owner_id: character.id,
+        quest_id: @quest_id,
+        is_account_quest: false,
+        state: :started,
+        conditions: %{},
+        start_time: System.system_time(:second)
+      })
+
+    {:ok, char_pid} = Managers.Character.start(character)
+    {:ok, quest_pid} = Managers.Quest.start_link(character.id)
+
+    on_exit(fn ->
+      if Process.alive?(quest_pid), do: GenServer.stop(quest_pid)
+      if Process.alive?(char_pid), do: GenServer.stop(char_pid)
+    end)
+
+    %{character: character}
+  end
+
+  # condition updates are asynchronous casts; poll until the assertion holds
+  defp wait_until(fun, attempts \\ 50)
+  defp wait_until(fun, attempts) when attempts <= 0, do: fun.()
+
+  defp wait_until(fun, attempts) do
+    try do
+      fun.()
+    rescue
+      ExUnit.AssertionError ->
+        Process.sleep(20)
+        wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp quest_conditions(character_id) do
+    Repo.get_by(Schema.CharacterQuest, %{owner_id: character_id, quest_id: @quest_id}).conditions
+  end
+
+  test "condition counters accumulate in memory and persist on flush", %{
+    character: character
+  } do
+    Managers.Quest.update_conditions(character.id, :map, 1, "", 0, "", 2_000_062)
+
+    wait_until(fn ->
+      {_account_quests, character_quests} = Managers.Quest.get_all_quests(character.id)
+      assert character_quests[@quest_id].conditions[0].counter == 1
+    end)
+
+    # the database row still holds the pre-event counters: ordinary events
+    # do not write
+    assert quest_conditions(character.id) == %{}
+
+    Managers.Quest.update_conditions(character.id, :map, 1, "", 0, "", 2_000_062)
+
+    :ok = Managers.Quest.flush(character.id)
+
+    assert %{"0" => 2} = quest_conditions(character.id)
+  end
+end

--- a/test/ms2ex/quest_manager_test.exs
+++ b/test/ms2ex/quest_manager_test.exs
@@ -8,18 +8,36 @@ defmodule Ms2ex.QuestManagerTest do
 
   import Ms2ex.TestHelpers
 
-  # a world quest with one map condition worth 2 visits
+  # a world quest with one map condition worth 2 visits, rewarding potions
   @quest_id 2_001_045
   @quest_metadata %{
     id: @quest_id,
-    basic: %{type: :world_quest},
-    conditions: [%{type: :map, value: 2, codes: %{range: nil, strings: [], integers: []}}]
+    basic: %{type: :world_quest, chapter_id: 0},
+    conditions: [%{type: :map, value: 2, codes: %{range: nil, strings: [], integers: []}}],
+    complete_reward: %{
+      exp: 0,
+      meso: 0,
+      treva: 0,
+      rue: 0,
+      essential_items: [],
+      essential_job_items: [],
+      selective_items: []
+    }
   }
 
   setup {Mimic, :set_mimic_global}
 
   setup do
-    stub_metadata(%{"quest:#{@quest_id}" => @quest_metadata})
+    stub_metadata(%{
+      "quest:#{@quest_id}" => @quest_metadata,
+      "item:20000022" => %{
+        id: 20_000_022,
+        limit: %{level: 0},
+        option: %{constant_id: 0},
+        property: %{type: 2, subtype: 2, stack_limit: 999},
+        slot_names: []
+      }
+    })
 
     account =
       Repo.insert!(%Schema.Account{
@@ -53,6 +71,7 @@ defmodule Ms2ex.QuestManagerTest do
       })
 
     {:ok, char_pid} = Managers.Character.start(character)
+    :ok = Managers.Inventory.start(character)
     {:ok, quest_pid} = Managers.Quest.start_link(character.id)
 
     on_exit(fn ->
@@ -100,5 +119,47 @@ defmodule Ms2ex.QuestManagerTest do
     :ok = Managers.Quest.flush(character.id)
 
     assert %{"0" => 2} = quest_conditions(character.id)
+  end
+
+  test "completing a quest marks it completed", %{character: character} do
+    Managers.Quest.update_conditions(character.id, :map, 1, "", 0, "", 2_000_062)
+    Managers.Quest.update_conditions(character.id, :map, 1, "", 0, "", 2_000_062)
+
+    wait_until(fn ->
+      {_account, character_quests} = Managers.Quest.get_all_quests(character.id)
+      assert character_quests[@quest_id].conditions[0].counter == 2
+    end)
+
+    assert {:ok, _quest} = Managers.Quest.complete(@quest_id, character.id)
+
+    assert %Schema.CharacterQuest{state: :completed} =
+             Repo.get_by(Schema.CharacterQuest, %{owner_id: character.id, quest_id: @quest_id})
+  end
+
+  # regression: grant_items must return the inventory add results (not the
+  # acquisition notification's :ok) so post-commit delivery can push the
+  # add-item packets
+  test "item rewards grant through the inventory and report their results", %{
+    character: character
+  } do
+    reward = %{
+      exp: 0,
+      meso: 0,
+      treva: 0,
+      rue: 0,
+      essential_items: [%{id: 20_000_022, amount: 3, rarity: 1}],
+      essential_job_items: [],
+      selective_items: []
+    }
+
+    prepared = Ms2ex.Managers.Quest.Rewards.prepare(character, reward)
+    {:ok, results} = Ms2ex.Managers.Quest.Rewards.grant_items(character, prepared)
+
+    assert [create: %Schema.Item{item_id: 20_000_022, amount: 3}] = results
+
+    :ok = Ms2ex.Managers.Quest.Rewards.deliver(character, reward, results)
+
+    assert %Schema.Item{amount: 3} =
+             Repo.get_by(Schema.Item, %{character_id: character.id, item_id: 20_000_022})
   end
 end


### PR DESCRIPTION
## Summary

Every gameplay event (mob kill, item pickup, quest accept…) fanned out through the quest manager's condition pipeline into `Context.Achievements.progress/7`, which ran **a SELECT per matching achievement plus a write per change** — a single kill with dozens of matching trophies meant dozens of queries. This PR moves achievement state into a manager, following the established context/manager split (contexts persist, managers own state — now documented in AGENTS.md).

### `Managers.Achievement` (`achievements:<char_id>`, started at login, stopped on disconnect)

- Rows load **once** at init; condition events walk the storage index in memory — zero SQL per event
- New rows insert the moment they are created; updates to existing rows batch into a **60-second flush**, also flushed on demand and on disconnect
- Trophy counts per category stay in memory and sync onto the character (`{:update_trophies, counts}`) instead of re-querying every row at login and on every grade change
- Grade completions notify the quest conditions tracking achievement progress (`revise_achieve_multi_grade`, `revise_achieve_single_grade`, `hero_achieve`), with the reached grade as target
- Stat-point and emote rewards apply automatically on rank-up; item and title rewards wait for the manual claim; gear-score trophies track a maximum instead of accumulating; load packets batch per 60 entries
- Skill point rewards stay pending (TODO — no skill point API yet)

### `Context.Achievements` → pure persistence

`list/create/update/save`. `save` forces the mutable fields because the in-memory row already carries new values — a plain cast computes an empty diff and `Repo.update` silently skips the SQL.

### Meta-trophy gating fix (found in testing)

A fresh character logging in unlocked **52 trophies**. Root cause: the rank-up feedback fires condition updates with the completing achievement id as the code, but those three condition types were not treated as code conditions — every notification counted into every meta-trophy and snowballed. They now gate on the tracked ids and the reached grade; replaying the login events against the real metadata completes exactly the two legitimate trophies (visit spawn map, visit continent).

## Test plan

- [x] 211 tests pass, credo clean, zero warnings
- [x] New manager tests: row created once per achievement, counter accumulates in memory and persists on flush, grade completion bumps trophy counts, stat-point rewards auto-apply on rank-up
- [x] In-game: trophies advance without query spam, login shows only the two map/continent unlocks on a fresh character, progress survives relog

Closes nothing on the roadmap directly; item 15 (Achievements) updated to [Partial] with the manager noted.