### PR TITLE
Flush deferred manager state on server shutdown

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -429,7 +429,10 @@ combat-heavy characters from accumulating document copies.
   flushed on demand and on stop) — ordinary gameplay events (kills,
   movement, pickups) no longer write one UPDATE per matching quest per
   event. Quest transitions that own their persistence (start, complete,
-  abandon, expire) still write through
+  abandon, expire) still write through. Application stop flushes every
+  live deferred manager before the supervision tree shuts down
+  (`Application.prep_stop/2` stops the ad-hoc per-character managers, whose
+  terminate callback writes the pending batch)
 - Auto-start gating: quests carrying an event tag never start on their own
   (event content starts only through a matching server event, and stale
   event quests would otherwise be auto-started at login and immediately

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -429,10 +429,12 @@ combat-heavy characters from accumulating document copies.
   flushed on demand and on stop) — ordinary gameplay events (kills,
   movement, pickups) no longer write one UPDATE per matching quest per
   event. Quest transitions that own their persistence (start, complete,
-  abandon, expire) still write through. Application stop flushes every
-  live deferred manager before the supervision tree shuts down
-  (`Application.prep_stop/2` stops the ad-hoc per-character managers, whose
-  terminate callback writes the pending batch)
+  abandon, expire) still write through. The per-character managers
+  (character, inventory, quest, achievement) live under a dynamic
+  supervisor (`Ms2ex.Managers.ManagerSupervisor`), so the application
+  teardown shuts every live one down instead of killing it silently —
+  the quest and achievement managers trap the shutdown signal and flush
+  their pending batches from their terminate callback
 - Auto-start gating: quests carrying an event tag never start on their own
   (event content starts only through a matching server event, and stale
   event quests would otherwise be auto-started at login and immediately

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -434,7 +434,9 @@ combat-heavy characters from accumulating document copies.
   supervisor (`Ms2ex.Managers.ManagerSupervisor`), so the application
   teardown shuts every live one down instead of killing it silently —
   the quest and achievement managers trap the shutdown signal and flush
-  their pending batches from their terminate callback
+  their pending batches from their terminate callback. The game session
+  monitors its managers and disconnects the client if one of them dies —
+  the game either works or the character relogs, never half-works
 - Auto-start gating: quests carrying an event tag never start on their own
   (event content starts only through a matching server event, and stale
   event quests would otherwise be auto-started at login and immediately

--- a/lib/ms2ex/application.ex
+++ b/lib/ms2ex/application.ex
@@ -3,23 +3,6 @@ defmodule Ms2ex.Application do
 
   use Application
 
-  # Runs before the supervision tree shuts down, while the ad-hoc
-  # per-character managers are still alive (they are not supervised, so
-  # they would otherwise be killed without their terminate callback ever
-  # running). Stopping them flushes the achievement/quest progress that is
-  # held in memory between periodic flushes.
-  def prep_stop(_state) do
-    for name <- :erlang.registered(),
-        prefix = Atom.to_string(name),
-        String.starts_with?(prefix, ["achievements:", "quest_manager:"]) do
-      pid = Process.whereis(name)
-
-      if pid != nil and Process.alive?(pid) do
-        GenServer.stop(pid, :shutdown, 5_000)
-      end
-    end
-  end
-
   def start(_type, _args) do
     :ets.new(:metadata, [:named_table, :set, :public, read_concurrency: true])
     Ms2ex.Context.WorldGraph.store()
@@ -39,6 +22,7 @@ defmodule Ms2ex.Application do
         # Start Oban (job queue + daily reset crontab)
         {Oban, oban_config()},
         # Start Managers
+        Ms2ex.Managers.ManagerSupervisor,
         Ms2ex.Managers.GlobalCounter,
         {Ms2ex.Managers.PartyManager, [name: Ms2ex.Managers.PartyManager]},
         {Ms2ex.Managers.Session, [name: Ms2ex.Managers.Session]}

--- a/lib/ms2ex/application.ex
+++ b/lib/ms2ex/application.ex
@@ -3,6 +3,23 @@ defmodule Ms2ex.Application do
 
   use Application
 
+  # Runs before the supervision tree shuts down, while the ad-hoc
+  # per-character managers are still alive (they are not supervised, so
+  # they would otherwise be killed without their terminate callback ever
+  # running). Stopping them flushes the achievement/quest progress that is
+  # held in memory between periodic flushes.
+  def prep_stop(_state) do
+    for name <- :erlang.registered(),
+        prefix = Atom.to_string(name),
+        String.starts_with?(prefix, ["achievements:", "quest_manager:"]) do
+      pid = Process.whereis(name)
+
+      if pid != nil and Process.alive?(pid) do
+        GenServer.stop(pid, :shutdown, 5_000)
+      end
+    end
+  end
+
   def start(_type, _args) do
     :ets.new(:metadata, [:named_table, :set, :public, read_concurrency: true])
     Ms2ex.Context.WorldGraph.store()

--- a/lib/ms2ex/context/quests.ex
+++ b/lib/ms2ex/context/quests.ex
@@ -137,12 +137,11 @@ defmodule Ms2ex.Context.Quests do
   defp hydrate_conditions(_conditions, _metadata), do: %{}
 
   defp load_counter(conditions, index) do
-    Map.get(conditions, index) ||
-      Map.get(conditions, Integer.to_string(index)) ||
-      get_in(conditions, [index, :counter]) ||
-      get_in(conditions, [index, "counter"]) ||
-      get_in(conditions, [Integer.to_string(index), :counter]) ||
-      get_in(conditions, [Integer.to_string(index), "counter"]) || 0
+    case Map.get(conditions, index) do
+      %{counter: counter} -> counter
+      counter when is_integer(counter) -> counter
+      _ -> 0
+    end
   end
 
   defp normalize_attrs(attrs) do

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -63,7 +63,13 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
 
   defp start_quest_manager(character_id) do
     case Process.whereis(:"quest_manager:#{character_id}") do
-      nil -> Managers.Quest.start(character_id)
+      nil ->
+        Managers.Quest.start(character_id)
+
+        case Process.whereis(:"quest_manager:#{character_id}") do
+          nil -> :ok
+          pid -> Process.monitor(pid)
+        end
       _ -> :ok
     end
   end

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -63,7 +63,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
 
   defp start_quest_manager(character_id) do
     case Process.whereis(:"quest_manager:#{character_id}") do
-      nil -> Managers.Quest.start_link(character_id)
+      nil -> Managers.Quest.start(character_id)
       _ -> :ok
     end
   end

--- a/lib/ms2ex/handlers/game/response_key.ex
+++ b/lib/ms2ex/handlers/game/response_key.ex
@@ -32,6 +32,7 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
       # the inventory manager must own the item rows before anything reads
       # them: every Context.Inventory/Equips call below goes through it
       :ok = Managers.Inventory.start(character)
+      monitor_manager(:inventories, character.id)
 
       character =
         character
@@ -52,9 +53,11 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
         end
 
       :ok = Managers.Achievement.start(character)
+      monitor_manager(:achievements, character.id)
 
       Managers.Character.start(character)
       Managers.Character.call(character, :monitor)
+      monitor_manager(:characters, character.id)
 
       character = Context.Characters.preload(character, friends: :rcpt)
       init_character(character)
@@ -113,6 +116,15 @@ defmodule Ms2ex.GameHandlers.ResponseKey do
   defp push_achievements(session, character) do
     Managers.Achievement.load(character)
     session
+  end
+
+  # a dead manager means a dead session: the client is disconnected instead
+  # of playing on with a partially broken character
+  defp monitor_manager(prefix, character_id) do
+    case Process.whereis(:"#{prefix}:#{character_id}") do
+      nil -> :ok
+      pid -> Process.monitor(pid)
+    end
   end
 
   defp maybe_set_party(character) do

--- a/lib/ms2ex/managers/achievement.ex
+++ b/lib/ms2ex/managers/achievement.ex
@@ -22,11 +22,16 @@ defmodule Ms2ex.Managers.Achievement do
   # documents; metadata is read from the storage cache at point of use.
 
   def start(%Schema.Character{id: id} = character) do
-    case GenServer.start(__MODULE__, character, name: process_name(id)) do
+    case Managers.ManagerSupervisor.start_child(__MODULE__, character, process_name(id)) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> :ok
       error -> error
     end
+  end
+
+  @doc false
+  def start_link(%Schema.Character{} = character) do
+    GenServer.start_link(__MODULE__, character, name: process_name(character.id))
   end
 
   def stop(%Schema.Character{id: id}), do: stop(id)
@@ -34,7 +39,7 @@ defmodule Ms2ex.Managers.Achievement do
   def stop(id) when is_integer(id) do
     case Process.whereis(process_name(id)) do
       nil -> :ok
-      pid -> GenServer.stop(pid)
+      pid -> Managers.ManagerSupervisor.terminate_child(pid)
     end
   end
 
@@ -92,6 +97,10 @@ defmodule Ms2ex.Managers.Achievement do
 
   @impl true
   def init(%Schema.Character{} = character) do
+    # deferred writes are flushed in terminate, which only runs on the
+    # teardown shutdown signal when exits are trapped
+    Process.flag(:trap_exit, true)
+
     achievements =
       [character.account_id, character.id]
       |> Enum.uniq()

--- a/lib/ms2ex/managers/character.ex
+++ b/lib/ms2ex/managers/character.ex
@@ -22,7 +22,16 @@ defmodule Ms2ex.Managers.Character do
   end
 
   def start(%Schema.Character{} = character) do
-    GenServer.start(__MODULE__, character, name: process_name(character.id))
+    Ms2ex.Managers.ManagerSupervisor.start_child(
+      __MODULE__,
+      character,
+      process_name(character.id)
+    )
+  end
+
+  @doc false
+  def start_link(%Schema.Character{} = character) do
+    GenServer.start_link(__MODULE__, character, name: process_name(character.id))
   end
 
   # ids of every online character, from the registered character processes

--- a/lib/ms2ex/managers/inventory.ex
+++ b/lib/ms2ex/managers/inventory.ex
@@ -3,6 +3,7 @@ defmodule Ms2ex.Managers.Inventory do
   use Ms2ex.Managers.Managed, prefix: "inventories", key: :character_id
 
   alias Ms2ex.Context
+  alias Ms2ex.Managers
   alias Ms2ex.Repo
   alias Ms2ex.Schema
   alias Ms2ex.Storage
@@ -17,11 +18,16 @@ defmodule Ms2ex.Managers.Inventory do
   # it.
 
   def start(%Schema.Character{id: id} = character) do
-    case GenServer.start(__MODULE__, character, name: process_name(id)) do
+    case Managers.ManagerSupervisor.start_child(__MODULE__, character, process_name(id)) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> :ok
       error -> error
     end
+  end
+
+  @doc false
+  def start_link(%Schema.Character{} = character) do
+    GenServer.start_link(__MODULE__, character, name: process_name(character.id))
   end
 
   def stop(%Schema.Character{id: id}), do: stop(id)
@@ -29,7 +35,7 @@ defmodule Ms2ex.Managers.Inventory do
   def stop(id) when is_integer(id) do
     case Process.whereis(process_name(id)) do
       nil -> :ok
-      pid -> GenServer.stop(pid)
+      pid -> Managers.ManagerSupervisor.terminate_child(pid)
     end
   end
 

--- a/lib/ms2ex/managers/manager_supervisor.ex
+++ b/lib/ms2ex/managers/manager_supervisor.ex
@@ -1,0 +1,44 @@
+defmodule Ms2ex.Managers.ManagerSupervisor do
+  @moduledoc """
+  Owns the per-character managers (character, inventory, quest, achievement).
+
+  Children are temporary: each one is started when its character logs in and
+  removed when the character disconnects — a crashed manager stays down until
+  the next login rather than restarting with partially stale state.
+
+  The quest and achievement managers trap exits and flush their deferred
+  writes in terminate, so both a disconnect and the application teardown
+  persist everything held in memory between periodic flushes.
+  """
+  use DynamicSupervisor
+
+  def start_link(init_arg),
+    do: DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+
+  @doc "Starts a per-character manager under this supervisor."
+  def start_child(module, character, name) do
+    child_spec = %{
+      id: name,
+      start: {module, :start_link, [character]},
+      restart: :temporary
+    }
+
+    DynamicSupervisor.start_child(__MODULE__, child_spec)
+  end
+
+  @doc """
+  Stops a manager process and removes it from the supervisor. No-op for a
+  process that already exited.
+  """
+  def terminate_child(pid) when is_pid(pid) do
+    case DynamicSupervisor.terminate_child(__MODULE__, pid) do
+      :ok -> :ok
+      {:error, :not_found} -> :ok
+    end
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/ms2ex/managers/quest.ex
+++ b/lib/ms2ex/managers/quest.ex
@@ -16,6 +16,8 @@ defmodule Ms2ex.Managers.Quest do
   alias Ms2ex.Storage
   import Ms2ex.Net.SenderSession, only: [push: 2]
 
+  require Logger
+
   @flush_interval :timer.minutes(1)
 
   # Constants
@@ -40,8 +42,19 @@ defmodule Ms2ex.Managers.Quest do
   # Client API
 
   @doc """
-  Starts a quest manager for a character.
+  Starts the quest manager for a character.
   """
+  def start(character_id) do
+    name = process_name(character_id)
+
+    case Managers.ManagerSupervisor.start_child(__MODULE__, character_id, name) do
+      {:ok, pid} -> {:ok, pid}
+      {:error, {:already_started, pid}} -> {:ok, pid}
+      error -> error
+    end
+  end
+
+  @doc false
   def start_link(character_id) do
     GenServer.start_link(__MODULE__, character_id, name: process_name(character_id))
   end
@@ -213,7 +226,7 @@ defmodule Ms2ex.Managers.Quest do
   def stop(character_id) do
     case Process.whereis(process_name(character_id)) do
       nil -> :ok
-      pid -> GenServer.stop(pid)
+      pid -> Managers.ManagerSupervisor.terminate_child(pid)
     end
   end
 
@@ -221,6 +234,10 @@ defmodule Ms2ex.Managers.Quest do
 
   @impl true
   def init(character_id) do
+    # deferred counters are flushed in terminate, which only runs on the
+    # teardown shutdown signal when exits are trapped
+    Process.flag(:trap_exit, true)
+
     {:ok, character} = Managers.Character.lookup(character_id)
 
     {account_quests, character_quests} =
@@ -721,11 +738,21 @@ defmodule Ms2ex.Managers.Quest do
     state.dirty
     |> Enum.reduce(state, fn quest_id, state ->
       case Managers.Quest.State.get_quest_from_state(quest_id, state) do
+        # transitions persist their own rows; the flush only carries
+        # condition counters for quests still in progress
+        %{state: quest_state} when quest_state != :started ->
+          %{state | dirty: MapSet.delete(state.dirty, quest_id)}
+
         nil ->
-          state
+          %{state | dirty: MapSet.delete(state.dirty, quest_id)}
 
         quest ->
-          Context.Quests.update_quest(quest, %{conditions: quest.conditions})
+          try do
+            Context.Quests.update_quest(quest, %{conditions: quest.conditions})
+          rescue
+            error -> Logger.warning("quest condition flush failed: #{Exception.message(error)}")
+          end
+
           %{state | dirty: MapSet.delete(state.dirty, quest_id)}
       end
     end)

--- a/lib/ms2ex/managers/quest/state.ex
+++ b/lib/ms2ex/managers/quest/state.ex
@@ -63,7 +63,8 @@ defmodule Ms2ex.Managers.Quest.State do
     attrs = %{
       state: :completed,
       end_time: now,
-      completion_count: quest.completion_count + 1
+      completion_count: quest.completion_count + 1,
+      conditions: quest.conditions
     }
 
     Context.Quests.update_quest(quest, attrs)

--- a/lib/ms2ex/net/session.ex
+++ b/lib/ms2ex/net/session.ex
@@ -122,6 +122,19 @@ defmodule Ms2ex.Net.Session do
     {:stop, :normal, state}
   end
 
+  # a per-character manager dying takes the session with it: the game
+  # either works or it does not, so instead of degrading into a partially
+  # broken session the client is disconnected and asked to relog
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    L.error(fn ->
+      "Manager #{inspect(pid)} died (#{inspect(reason)}) — disconnecting session"
+    end)
+
+    shutdown(state.socket, state.transport, state.sender_pid)
+
+    {:stop, :shutdown, state}
+  end
+
   def handle_info({:update, attrs}, state), do: {:noreply, Map.merge(state, attrs)}
 
   def handle_info({:EXIT, _port, _reason}, state), do: {:noreply, state}

--- a/test/ms2ex/achievement_manager_test.exs
+++ b/test/ms2ex/achievement_manager_test.exs
@@ -138,6 +138,27 @@ defmodule Ms2ex.AchievementManagerTest do
     assert Map.keys(grades) == ["1"]
   end
 
+  # server shutdown stops the manager, whose terminate flushes pending
+  # progress; the state snapshot + direct terminate call mirrors that path
+  test "stopping the manager flushes pending progress", %{character: character} do
+    Managers.Achievement.update(character.id, :monster_kill)
+
+    # the row is created with its insert-time defaults; the accumulated
+    # counter lives in memory
+    wait_until(fn ->
+      assert length(Achievements.list(character.id)) == 1
+    end)
+
+    Managers.Achievement.update(character.id, :monster_kill)
+
+    pid = Process.whereis(:"achievements:#{character.id}")
+    state = :sys.get_state(pid)
+    GenServer.stop(pid, :normal)
+    Managers.Achievement.terminate(:shutdown, state)
+
+    assert [%Schema.Achievement{counter: 2}] = Achievements.list(character.id)
+  end
+
   test "stat point rewards are granted automatically on rank up", %{character: character} do
     Managers.Achievement.update(character.id, :quest_accept)
 

--- a/test/ms2ex/achievement_manager_test.exs
+++ b/test/ms2ex/achievement_manager_test.exs
@@ -75,10 +75,20 @@ defmodule Ms2ex.AchievementManagerTest do
     achievement_pid = Process.whereis(:"achievements:#{character.id}")
 
     on_exit(fn ->
-      if achievement_pid != nil and Process.alive?(achievement_pid),
-        do: GenServer.stop(achievement_pid)
+      # the managers outlive the test process (the supervisor owns them
+      # now), so their teardown runs after the test's sandbox checkout is
+      # gone: check out a connection here and grant it to the live
+      # managers so the achievement manager's terminate flush can write
+      Ecto.Adapters.SQL.Sandbox.checkout(Repo)
 
-      if Process.alive?(char_pid), do: GenServer.stop(char_pid)
+      Enum.each([achievement_pid, char_pid], fn pid ->
+        if pid != nil and Process.alive?(pid) do
+          Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+          GenServer.stop(pid)
+        end
+      end)
+
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
     end)
 
     # both managers read and write the database from their own processes
@@ -138,8 +148,9 @@ defmodule Ms2ex.AchievementManagerTest do
     assert Map.keys(grades) == ["1"]
   end
 
-  # server shutdown stops the manager, whose terminate flushes pending
-  # progress; the state snapshot + direct terminate call mirrors that path
+  # the stop path is the teardown path: the manager supervisor delivers
+  # the shutdown exit signal, the trapped exit runs terminate, and the
+  # pending counters land in the database
   test "stopping the manager flushes pending progress", %{character: character} do
     Managers.Achievement.update(character.id, :monster_kill)
 
@@ -151,10 +162,7 @@ defmodule Ms2ex.AchievementManagerTest do
 
     Managers.Achievement.update(character.id, :monster_kill)
 
-    pid = Process.whereis(:"achievements:#{character.id}")
-    state = :sys.get_state(pid)
-    GenServer.stop(pid, :normal)
-    Managers.Achievement.terminate(:shutdown, state)
+    :ok = Managers.Achievement.stop(character.id)
 
     assert [%Schema.Achievement{counter: 2}] = Achievements.list(character.id)
   end

--- a/test/ms2ex/quest_manager_test.exs
+++ b/test/ms2ex/quest_manager_test.exs
@@ -136,6 +136,25 @@ defmodule Ms2ex.QuestManagerTest do
              Repo.get_by(Schema.CharacterQuest, %{owner_id: character.id, quest_id: @quest_id})
   end
 
+  # server shutdown stops the manager, whose terminate flushes pending
+  # condition counters; the state snapshot + direct terminate call mirrors
+  # that path
+  test "stopping the manager flushes pending counters", %{character: character} do
+    Managers.Quest.update_conditions(character.id, :map, 1, "", 0, "", 2_000_062)
+
+    wait_until(fn ->
+      {_account, character_quests} = Managers.Quest.get_all_quests(character.id)
+      assert character_quests[@quest_id].conditions[0].counter == 1
+    end)
+
+    pid = Process.whereis(:"quest_manager:#{character.id}")
+    state = :sys.get_state(pid)
+    GenServer.stop(pid, :normal)
+    Managers.Quest.terminate(:shutdown, state)
+
+    assert %{"0" => 1} = quest_conditions(character.id)
+  end
+
   # regression: grant_items must return the inventory add results (not the
   # acquisition notification's :ok) so post-commit delivery can push the
   # add-item packets

--- a/test/ms2ex/quest_manager_test.exs
+++ b/test/ms2ex/quest_manager_test.exs
@@ -72,11 +72,24 @@ defmodule Ms2ex.QuestManagerTest do
 
     {:ok, char_pid} = Managers.Character.start(character)
     :ok = Managers.Inventory.start(character)
-    {:ok, quest_pid} = Managers.Quest.start_link(character.id)
+    {:ok, quest_pid} = Managers.Quest.start(character.id)
 
     on_exit(fn ->
-      if Process.alive?(quest_pid), do: GenServer.stop(quest_pid)
-      if Process.alive?(char_pid), do: GenServer.stop(char_pid)
+      # the managers outlive the test process (the supervisor owns them
+      # now), so their teardown runs after the test's sandbox checkout is
+      # gone: check out a connection here and grant it to the live
+      # managers so the quest manager's terminate flush can write
+      Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+      Enum.each([quest_pid, char_pid], fn pid ->
+        if Process.alive?(pid) do
+          Ecto.Adapters.SQL.Sandbox.allow(Repo, self(), pid)
+          GenServer.stop(pid)
+        end
+      end)
+
+      Managers.Inventory.stop(character.id)
+      Ecto.Adapters.SQL.Sandbox.checkin(Repo)
     end)
 
     %{character: character}
@@ -134,11 +147,16 @@ defmodule Ms2ex.QuestManagerTest do
 
     assert %Schema.CharacterQuest{state: :completed} =
              Repo.get_by(Schema.CharacterQuest, %{owner_id: character.id, quest_id: @quest_id})
+
+    # stop inside the test body: the deferred counters must flush while
+    # the sandbox transaction is still open (on_exit runs after the
+    # rollback)
+    :ok = Managers.Quest.stop(character.id)
   end
 
-  # server shutdown stops the manager, whose terminate flushes pending
-  # condition counters; the state snapshot + direct terminate call mirrors
-  # that path
+  # the stop path is the teardown path: the manager supervisor delivers
+  # the shutdown exit signal, the trapped exit runs terminate, and the
+  # pending counters land in the database
   test "stopping the manager flushes pending counters", %{character: character} do
     Managers.Quest.update_conditions(character.id, :map, 1, "", 0, "", 2_000_062)
 
@@ -147,10 +165,7 @@ defmodule Ms2ex.QuestManagerTest do
       assert character_quests[@quest_id].conditions[0].counter == 1
     end)
 
-    pid = Process.whereis(:"quest_manager:#{character.id}")
-    state = :sys.get_state(pid)
-    GenServer.stop(pid, :normal)
-    Managers.Quest.terminate(:shutdown, state)
+    :ok = Managers.Quest.stop(character.id)
 
     assert %{"0" => 1} = quest_conditions(character.id)
   end


### PR DESCRIPTION
## Summary

Supervises the per-character managers, and makes a manager crash mean a clean disconnect instead of a half-broken session.

### Problem

The character, inventory, quest and achievement managers are started ad-hoc at login — **not part of any supervision tree**. Two consequences:

1. On **application stop** they received no shutdown signal: they were killed without `terminate/2` ever running, losing up to one flush interval of in-memory achievement/quest progress.
2. On a **crash** they stayed dead until relog — while the session kept playing with a partially broken character (no inventory, no quest/achievement progress). *The game either works or it doesn't.*

### Fix

**Supervision** — new `Ms2ex.Managers.ManagerSupervisor` (a `DynamicSupervisor` in the application tree) owns the four per-character managers:
- started at login (`DynamicSupervisor.start_child`), removed on disconnect (`terminate_child`)
- `restart: :temporary` — a crash stays down until the next login rather than restarting with partially stale state (restart intensity on a DynamicSupervisor is supervisor-global, so auto-restarting one character's crash loop could take every character's managers down)
- the quest and achievement managers trap exits, so the tree's teardown shutdown signal runs their `terminate/2`, which flushes the deferred batches while the Repo is still up

**Fail-fast sessions** — the game session monitors its four managers; if any of them exits, the session logs it, closes the socket, and stops: the client is disconnected and the normal disconnect cascade (character manager cleanup) stops the remaining managers with their flushes intact. A relog brings everything back fresh from the database.

**Quest flush hardening** (found while testing):
- a quest completion persists its **final condition counters** atomically with the state change, so the flush has nothing left to write for completed quests (previously the flush could fight the completion write and crash the manager with a stale-struct error)
- `load_counter` no longer double-wraps already-hydrated condition entries
- a failed flush write is logged and dropped instead of killing the manager

## Test plan

- [x] Shutdown-flush contract tests for both managers (stop → terminate → deferred counters land in the database)
- [x] Quest completion test (state `:completed` persisted, no flush crash)
- [x] 216 tests pass, credo clean, zero warnings