### PR TITLE
Instanced maps: solo maps get a private field per entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Completed work, newest first. Open items live in [ROADMAP.md](ROADMAP.md).
 
+
+- Instanced maps: the instance-field table is now projected
+  (`server.instancefield.xml`) and `solo` maps (every tutorial and quest
+  instance) allocate a private field per entry instead of dropping
+  everyone into one shared map — fixes players colliding in the tutorial
+  and breaking each other's progression. Field process names carry the
+  instance id; instanced maps are never persisted as the character's
+  current map, so a relog returns the player to where the instance was
+  entered from (reference parity). Ingest grew an
+  `--probe-instance-field` dump of the raw table.
 - Field manager reorganization: moved the field process API, PubSub
   broadcast topology and the enter/leave/change_field lifecycle out of
   `Context.Field` (deleted) onto `Managers.Field`, matching the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,10 +11,9 @@ Completed work, newest first. Open items live in [ROADMAP.md](ROADMAP.md).
   once per transition and carried on the character, and the field's
   PubSub topic carries it too, so instances never hear each other's
   packets; scripted cross-map moves stop the solo field they vacated.
-  Instanced maps are never persisted as the character's current map, so
-  a relog returns the player to where the instance was entered from
-  (reference parity). Ingest grew an `--probe-instance-field` dump of
-  the raw table.
+  A relog mid-instanced-map lands in a fresh instance of the same stage
+  (reference `SpawnPlayer` semantics). Ingest grew an
+  `--probe-instance-field` dump of the raw table.
 - Field manager reorganization: moved the field process API, PubSub
   broadcast topology and the enter/leave/change_field lifecycle out of
   `Context.Field` (deleted) onto `Managers.Field`, matching the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,11 +7,14 @@ Completed work, newest first. Open items live in [ROADMAP.md](ROADMAP.md).
   (`server.instancefield.xml`) and `solo` maps (every tutorial and quest
   instance) allocate a private field per entry instead of dropping
   everyone into one shared map — fixes players colliding in the tutorial
-  and breaking each other's progression. Field process names carry the
-  instance id; instanced maps are never persisted as the character's
-  current map, so a relog returns the player to where the instance was
-  entered from (reference parity). Ingest grew an
-  `--probe-instance-field` dump of the raw table.
+  and breaking each other's progression. The instance id is allocated
+  once per transition and carried on the character, and the field's
+  PubSub topic carries it too, so instances never hear each other's
+  packets; scripted cross-map moves stop the solo field they vacated.
+  Instanced maps are never persisted as the character's current map, so
+  a relog returns the player to where the instance was entered from
+  (reference parity). Ingest grew an `--probe-instance-field` dump of
+  the raw table.
 - Field manager reorganization: moved the field process API, PubSub
   broadcast topology and the enter/leave/change_field lifecycle out of
   `Context.Field` (deleted) onto `Managers.Field`, matching the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,7 @@ started.
 ## P1 — Core combat loop
 
 - [Field manager](features/field-manager.md) — [Partial]
+- [Instanced maps](features/instanced-maps.md) — [Partial]
 - [Player death & revive](features/player-death-revive.md) — [Partial]
 - [Mob AI: aggro, chase & attack](features/mob-ai.md) — [Open]
 - [Damage pipeline](features/damage-pipeline.md) — [Partial]

--- a/docs/features/field-manager.md
+++ b/docs/features/field-manager.md
@@ -63,8 +63,13 @@ process names come from `field_name/2` (`:"field:#{map}:channel:#{ch}"`).
 map instance is not up yet (init loads portals, interact objects, banners,
 liftables and trigger scripts; npc spawn docs stream in via messages so
 the first trigger ticks wait for them — `spawn_docs_pending`).
-`leave/1` removes a character; the process stops itself when the last
-session leaves (`:maybe_stop`). `change_field/2..4` leaves the old field,
+`leave/1` removes a character. When the last session leaves, what
+happens depends on the field: shared fields (instance 0) linger for five
+minutes — a one-shot timer cancelled by the next join — before stopping,
+so a player who walked out (or relogged) rejoins live state instead of a
+fresh field; instanced fields stop as soon as they empty out, since a
+fresh instance is allocated per entry and nothing can rejoin them.
+`change_field/2..4` leaves the old field,
 marks the discovered map, and pushes `RequestFieldEnter` to the client.
 
 ## Layering debt (follow-ups)

--- a/docs/features/instanced-maps.md
+++ b/docs/features/instanced-maps.md
@@ -16,8 +16,17 @@ absent from the table are ordinary shared fields.
   (`Managers.Field.field_name/3`): two players entering the same `solo`
   tutorial map land in two independent field processes — own npcs,
   own trigger machines, own drops.
-- `Managers.Field.instance_id/1` allocates a fresh unique id per call
-  for `solo` maps and returns 0 (shared) for everything else.
+- The instance id is allocated once per transition and carried on the
+  character: `change_field` stamps it into `change_map`,
+  `Managers.Field.assign_instance/1` binds it before the field subscribe,
+  and `enter/1` reuses it — a repeated field enter for the same visit
+  rejoins the same field instead of spawning another one.
+- The field's PubSub topic carries the instance id too (`init/3`-built
+  via `field_name/3`), so two solo instances of the same map never hear
+  each other's packets; session-side topic helpers read
+  `character.field_instance`.
+- `Managers.Field.instance_id/1` allocates a fresh unique id for `solo`
+  maps and returns 0 (shared) for everything else.
 - Relog parity: instanced maps are never persisted as the character's
   current map (`response_field_enter` skips the `map_id` update), so a
   relog returns the player to the map the instance was entered from.

--- a/docs/features/instanced-maps.md
+++ b/docs/features/instanced-maps.md
@@ -1,0 +1,43 @@
+# Instanced maps
+
+Status: instancing is metadata-driven. The instance-field table
+(`server.instancefield.xml`, projected from the game's
+`table/Server/InstanceField.xml`) lists maps that must not be shared:
+`solo` maps (tutorials, quest instances) allocate a private field per
+entry; `channel_scale` maps keep one shared field per channel; maps
+absent from the table are ordinary shared fields.
+
+## How it works
+
+- `Storage.Tables.InstanceFields` exposes the per-map docs (`:type`,
+  `:instance_id`, `:pool_count`, `:max_count`, `:save_field`,
+  `:npc_stat_factor_id`), `instanced?/1` and `solo?/1`.
+- Field process names carry the instance id
+  (`Managers.Field.field_name/3`): two players entering the same `solo`
+  tutorial map land in two independent field processes — own npcs,
+  own trigger machines, own drops.
+- `Managers.Field.instance_id/1` allocates a fresh unique id per call
+  for `solo` maps and returns 0 (shared) for everything else.
+- Relog parity: instanced maps are never persisted as the character's
+  current map (`response_field_enter` skips the `map_id` update), so a
+  relog returns the player to the map the instance was entered from.
+  In-memory the character still carries the instance map, so quest
+  conditions and guild map updates keep working inside it.
+
+## Reference parity notes
+
+- `InstanceType` values from the game table: solo, channelScale,
+  massiveEvent, ugcMap, GameMaker, GuildEvent, DungeonLobby, GuildHouse,
+  WeddingHall, FieldWar, ... — the docs' `:type` atom mirrors the table.
+- The reference keys fields `(MapId, RoomId)` with a global id counter
+  and creates a fresh room per entry for the default (solo) case.
+
+## Still missing
+
+- party follow: joining a leader's existing instance (carry the
+  leader's instance id instead of allocating)
+- other instance types: dungeon lobbies/rooms, guild houses/events,
+  wedding halls, massive events with room pools (`pool_count`)
+- `max_count` caps on channel-scale instances
+- `save_field` (persist and restore a solo instance's state across
+  sessions) and `npc_stat_factor_id` scaling

--- a/docs/features/instanced-maps.md
+++ b/docs/features/instanced-maps.md
@@ -27,6 +27,11 @@ absent from the table are ordinary shared fields.
   `character.field_instance`.
 - `Managers.Field.instance_id/1` allocates a fresh unique id for `solo`
   maps and returns 0 (shared) for everything else.
+- Return maps: when a field change enters a map that declares an
+  `enter_return_id`, the hub is persisted instead of the map itself (the
+  reference's logout reset, collapsed from its 3-deep return-map stack —
+  ms2ex deliberately skips that stack's stale-entry quirk). The cube
+  return-map packet advertises the same target.
 - Relog behavior: the current map persists through instanced maps too —
   the reference's `SpawnPlayer` sets `Character.MapId` on every entry and
   only maps that push a return-map (`InstanceType.none` with an
@@ -49,9 +54,6 @@ absent from the table are ordinary shared fields.
   teleport still runs while a cinematic or scripted path move controls
   the player (same gap as trigger-runtime's "movement is not locked"
   note) — guard it with the field's guide-hold state
-- return-map stack: the reference pushes `EnterReturnId` on
-  `InstanceType.none`/`SaveField` maps and resets the saved map to it at
-  logout (houses, dungeons); ms2ex has no return-map stack yet
 - navmesh coverage: scripted maps whose xblock has no navmesh skip the
   move_user walkable-ground check (see `navmesh.md` — the class-intro
   chain is covered, the rest is flag-by-flag)

--- a/docs/features/instanced-maps.md
+++ b/docs/features/instanced-maps.md
@@ -45,6 +45,9 @@ absent from the table are ordinary shared fields.
 
 - party follow: joining a leader's existing instance (carry the
   leader's instance id instead of allocating)
+- navmesh coverage: scripted maps whose xblock has no navmesh skip the
+  move_user walkable-ground check (see `navmesh.md` — the class-intro
+  chain is covered, the rest is flag-by-flag)
 - other instance types: dungeon lobbies/rooms, guild houses/events,
   wedding halls, massive events with room pools (`pool_count`)
 - `max_count` caps on channel-scale instances

--- a/docs/features/instanced-maps.md
+++ b/docs/features/instanced-maps.md
@@ -27,11 +27,11 @@ absent from the table are ordinary shared fields.
   `character.field_instance`.
 - `Managers.Field.instance_id/1` allocates a fresh unique id for `solo`
   maps and returns 0 (shared) for everything else.
-- Relog parity: instanced maps are never persisted as the character's
-  current map (`response_field_enter` skips the `map_id` update), so a
-  relog returns the player to the map the instance was entered from.
-  In-memory the character still carries the instance map, so quest
-  conditions and guild map updates keep working inside it.
+- Relog behavior: the current map persists through instanced maps too —
+  the reference's `SpawnPlayer` sets `Character.MapId` on every entry and
+  only maps that push a return-map (`InstanceType.none` with an
+  `EnterReturnId`, or `SaveField` maps) reset it at logout. A relog
+  mid-tutorial therefore lands in a fresh instance of the same stage.
 
 ## Reference parity notes
 
@@ -45,6 +45,13 @@ absent from the table are ordinary shared fields.
 
 - party follow: joining a leader's existing instance (carry the
   leader's instance id instead of allocating)
+- OOB recovery during scripted sequences: `user_sync`'s out-of-bounds
+  teleport still runs while a cinematic or scripted path move controls
+  the player (same gap as trigger-runtime's "movement is not locked"
+  note) — guard it with the field's guide-hold state
+- return-map stack: the reference pushes `EnterReturnId` on
+  `InstanceType.none`/`SaveField` maps and resets the saved map to it at
+  logout (houses, dungeons); ms2ex has no return-map stack yet
 - navmesh coverage: scripted maps whose xblock has no navmesh skip the
   move_user walkable-ground check (see `navmesh.md` — the class-intro
   chain is covered, the rest is flag-by-flag)
@@ -53,3 +60,5 @@ absent from the table are ordinary shared fields.
 - `max_count` caps on channel-scale instances
 - `save_field` (persist and restore a solo instance's state across
   sessions) and `npc_stat_factor_id` scaling
+- entry gating: `backup_source_portal` and `open_type`/`open_value` are
+  projected but unused

--- a/docs/features/instanced-maps.md
+++ b/docs/features/instanced-maps.md
@@ -46,6 +46,10 @@ absent from the table are ordinary shared fields.
 - The reference keys fields `(MapId, RoomId)` with a global id counter
   and creates a fresh room per entry for the default (solo) case.
 
+- instanced fields stop immediately when they empty out (nothing can
+  rejoin them); shared fields linger five minutes for returning players
+  (see `field-manager.md`)
+
 ## Still missing
 
 - party follow: joining a leader's existing instance (carry the

--- a/docs/features/navmesh.md
+++ b/docs/features/navmesh.md
@@ -10,8 +10,10 @@ platform edge no longer drop players out of the world.
 
 ## Still missing
 
-- generating navmeshes for the remaining maps (the flag currently covers the
-  verified tutorial xblocks)
+- generating navmeshes for the remaining maps (the flag covers the
+  verified tutorial xblocks plus the class-intro chain 52000100-52000105;
+  the class intro's staging anchors hang off the platform edge, so these
+  maps are required for the wizard tutorial)
 - npc pathing queries over the stored tiles (prerequisite for mob AI)
 - auditing the generated meshes (nif assets whose llid lookup failed leave
   small gaps in walkable coverage)

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -12,6 +12,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
 
     # Check if character is changing map
     character = maybe_change_map(character)
+    character = Managers.Field.assign_instance(character)
     Managers.Character.call(character, {:update, character})
 
     run(session, fn -> Managers.Field.subscribe(character) end)
@@ -53,7 +54,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
 
     Managers.GuildServer.call(
       character.guild_id,
-      {:update_member_map, character.id, character.map_id}
+      {:update_member_map, character.id, character.map_id, character.field_instance}
     )
 
     continent = Storage.Maps.get_property(character.map_id) |> Map.get(:continent, 0)
@@ -94,6 +95,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     # to it, and a coordinate from the previous map is out of bounds here too
     character
     |> Map.put(:change_map, nil)
+    |> Map.put(:field_instance, new_map.instance)
     |> Map.put(:position, new_map.position)
     |> Map.put(:safe_position, new_map.position)
     |> Map.put(:rotation, new_map.rotation)

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -79,7 +79,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     run(character, fn -> Managers.Field.unsubscribe(character) end)
 
     new_map = character.change_map
-    character = Managers.Field.update_current_map(character, new_map)
+    character = persist_current_map(character, new_map)
 
     # the safe position has to follow the map: out-of-bounds recovery teleports
     # to it, and a coordinate from the previous map is out of bounds here too
@@ -89,6 +89,16 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     |> Map.put(:position, new_map.position)
     |> Map.put(:safe_position, new_map.position)
     |> Map.put(:rotation, new_map.rotation)
+  end
+
+  # the persisted map is the map's enter_return_id when it declares one
+  # (a relog inside a quest instance lands at its hub); the in-memory map
+  # id follows the actual map — the field process is built from it
+  defp persist_current_map(character, new_map) do
+    {:ok, character} =
+      Context.Characters.update(character, %{map_id: Managers.Field.return_map_id(new_map.id)})
+
+    Map.put(character, :map_id, new_map.id)
   end
 
   defp start_quest_manager(character_id) do

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -79,17 +79,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     run(character, fn -> Managers.Field.unsubscribe(character) end)
 
     new_map = character.change_map
-
-    # instanced maps are never persisted as the character's current map:
-    # the pre-instance map stays saved, so a relog returns the player to
-    # where the instance was entered from
-    character =
-      if Storage.Tables.InstanceFields.instanced?(new_map.id) do
-        character
-      else
-        {:ok, character} = Context.Characters.update(character, %{map_id: new_map.id})
-        character
-      end
+    character = persist_current_map(character, new_map)
 
     # the safe position has to follow the map: out-of-bounds recovery teleports
     # to it, and a coordinate from the previous map is out of bounds here too
@@ -99,6 +89,18 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     |> Map.put(:position, new_map.position)
     |> Map.put(:safe_position, new_map.position)
     |> Map.put(:rotation, new_map.rotation)
+  end
+
+  # instanced maps are never persisted as the character's current map:
+  # the pre-instance map stays saved, so a relog returns the player to
+  # where the instance was entered from
+  defp persist_current_map(character, new_map) do
+    if Storage.Tables.InstanceFields.instanced?(new_map.id) do
+      character
+    else
+      {:ok, character} = Context.Characters.update(character, %{map_id: new_map.id})
+      character
+    end
   end
 
   defp start_quest_manager(character_id) do

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -78,7 +78,17 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     run(character, fn -> Managers.Field.unsubscribe(character) end)
 
     new_map = character.change_map
-    {:ok, character} = Context.Characters.update(character, %{map_id: new_map.id})
+
+    # instanced maps are never persisted as the character's current map:
+    # the pre-instance map stays saved, so a relog returns the player to
+    # where the instance was entered from
+    character =
+      if Storage.Tables.InstanceFields.instanced?(new_map.id) do
+        character
+      else
+        {:ok, character} = Context.Characters.update(character, %{map_id: new_map.id})
+        character
+      end
 
     # the safe position has to follow the map: out-of-bounds recovery teleports
     # to it, and a coordinate from the previous map is out of bounds here too

--- a/lib/ms2ex/handlers/game/response_field_enter.ex
+++ b/lib/ms2ex/handlers/game/response_field_enter.ex
@@ -79,7 +79,7 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     run(character, fn -> Managers.Field.unsubscribe(character) end)
 
     new_map = character.change_map
-    character = persist_current_map(character, new_map)
+    character = Managers.Field.update_current_map(character, new_map)
 
     # the safe position has to follow the map: out-of-bounds recovery teleports
     # to it, and a coordinate from the previous map is out of bounds here too
@@ -89,18 +89,6 @@ defmodule Ms2ex.GameHandlers.ResponseFieldEnter do
     |> Map.put(:position, new_map.position)
     |> Map.put(:safe_position, new_map.position)
     |> Map.put(:rotation, new_map.rotation)
-  end
-
-  # instanced maps are never persisted as the character's current map:
-  # the pre-instance map stays saved, so a relog returns the player to
-  # where the instance was entered from
-  defp persist_current_map(character, new_map) do
-    if Storage.Tables.InstanceFields.instanced?(new_map.id) do
-      character
-    else
-      {:ok, character} = Context.Characters.update(character, %{map_id: new_map.id})
-      character
-    end
   end
 
   defp start_quest_manager(character_id) do

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -54,6 +54,23 @@ defmodule Ms2ex.Managers.Field do
   # -- lifecycle -------------------------------------------------------------
 
   @doc """
+  Persists the character's current map after a field change. Instanced
+  maps are never persisted — the pre-instance map stays saved, so a relog
+  returns the player to where the instance was entered from — but the
+  in-memory map id follows the new map in both cases: the field process
+  for the visit is built from it.
+  """
+  @spec update_current_map(Schema.Character.t(), map()) :: Schema.Character.t()
+  def update_current_map(%Schema.Character{} = character, %{id: map_id} = _new_map) do
+    if Storage.Tables.InstanceFields.instanced?(map_id) do
+      Map.put(character, :map_id, map_id)
+    else
+      {:ok, character} = Context.Characters.update(character, %{map_id: map_id})
+      character
+    end
+  end
+
+  @doc """
   Binds the character to a field instance: a pending `change_map` instance
   (fresh allocation from `change_field/2,4`) wins, an existing stamp is
   kept while the character stays on the same field, anything else
@@ -229,7 +246,6 @@ defmodule Ms2ex.Managers.Field do
   def field_name(map_id, channel_id, instance_id) do
     :"field:#{map_id}:channel:#{channel_id}:instance:#{instance_id || 0}"
   end
-
 
   # -- process plumbing ------------------------------------------------------
 

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -47,6 +47,12 @@ defmodule Ms2ex.Managers.Field do
   @npc_tick_intval 15
   @banner_tick_intval :timer.seconds(30)
 
+  # how long an empty shared field stays up for players who walked out and
+  # may walk (or relog) back in; the reference loops on the same idea
+  # (FieldDisposeEmptyTime). Instanced fields are skipped: a fresh instance
+  # is allocated per entry, so an emptied one can never be rejoined
+  @shared_dispose_delay :timer.minutes(5)
+
   # one app-wide counter feeds players and mounts, while each field instance
   # owns a local counter for npcs, portals, spawn points and items
   @local_id_counter 50_000_000
@@ -631,6 +637,7 @@ defmodule Ms2ex.Managers.Field do
         regions: %{},
         sessions: %{},
         stage: MapSet.new(),
+        dispose_timer: nil,
         tombstones: %{},
         topic: field_name
       }
@@ -645,11 +652,15 @@ defmodule Ms2ex.Managers.Field do
     {:ok, state, {:continue, {:add_character, character}}}
   end
 
-  def handle_continue({:add_character, character}, state),
-    do: {:noreply, __MODULE__.Character.add_character(character, state)}
+  def handle_continue({:add_character, character}, state) do
+    state = __MODULE__.Character.add_character(character, state)
+    {:noreply, maybe_cancel_dispose(state)}
+  end
 
-  def handle_call({:add_character, character}, _from, state),
-    do: {:reply, {:ok, self()}, __MODULE__.Character.add_character(character, state)}
+  def handle_call({:add_character, character}, _from, state) do
+    state = __MODULE__.Character.add_character(character, state)
+    {:reply, {:ok, self()}, maybe_cancel_dispose(state)}
+  end
 
   def handle_call({:remove_character, character}, _from, state) do
     send(self(), :maybe_stop)
@@ -975,17 +986,58 @@ defmodule Ms2ex.Managers.Field do
     {:noreply, state}
   end
 
+  # sent whenever a character leaves the field: shared fields linger for
+  # a grace window (a party member may be right behind), instanced fields
+  # stop as soon as they empty out
   def handle_info(:maybe_stop, state) do
     if Enum.empty?(state.sessions) do
-      Logger.info("Field #{state.map_id} @ Channel #{state.channel_id} is empty. Stopping.")
-      {:stop, :normal, state}
+      if state.instance == 0 do
+        {:noreply, schedule_dispose(state)}
+      else
+        Logger.info(
+          "Field #{state.map_id} @ Channel #{state.channel_id} instance #{state.instance} is empty. Stopping."
+        )
+
+        {:stop, :normal, state}
+      end
     else
       {:noreply, state}
+    end
+  end
+
+  def handle_info(:dispose_if_empty, state) do
+    if Enum.empty?(state.sessions) do
+      Logger.info(
+        "Field #{state.map_id} @ Channel #{state.channel_id} empty for 5 minutes. Stopping."
+      )
+
+      {:stop, :normal, state}
+    else
+      {:noreply, %{state | dispose_timer: nil}}
     end
   end
 
   def handle_info(data, state) do
     Logger.warning("[Field] Unknown message: #{inspect(data)}")
     {:noreply, state}
+  end
+
+  defp schedule_dispose(state) do
+    if is_reference(state.dispose_timer), do: Process.cancel_timer(state.dispose_timer)
+
+    Logger.info(
+      "Field #{state.map_id} @ Channel #{state.channel_id} is empty. Stopping in 5 minutes unless someone joins."
+    )
+
+    %{state | dispose_timer: Process.send_after(self(), :dispose_if_empty, @shared_dispose_delay)}
+  end
+
+  defp maybe_cancel_dispose(%{sessions: sessions} = state) do
+    if Enum.empty?(sessions) do
+      state
+    else
+      if is_reference(state.dispose_timer), do: Process.cancel_timer(state.dispose_timer)
+      %{state | dispose_timer: nil}
+    end
   end
 end

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -92,8 +92,8 @@ defmodule Ms2ex.Managers.Field do
       {:error, {:already_started, pid}} ->
         call(pid, {:add_character, character})
 
-      error ->
-        error
+      result ->
+        result
     end
   end
 

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -54,20 +54,16 @@ defmodule Ms2ex.Managers.Field do
   # -- lifecycle -------------------------------------------------------------
 
   @doc """
-  Persists the character's current map after a field change. Instanced
-  maps are never persisted — the pre-instance map stays saved, so a relog
-  returns the player to where the instance was entered from — but the
-  in-memory map id follows the new map in both cases: the field process
-  for the visit is built from it.
+  Persists the character's current map after a field change; the in-memory
+  map id follows the new map. Instanced maps persist like any other: the
+  reference saves the current stage on quit (only maps that push a
+  return-map reset it, which plain solo maps never do), so a relog lands
+  in a fresh instance of the same stage.
   """
   @spec update_current_map(Schema.Character.t(), map()) :: Schema.Character.t()
   def update_current_map(%Schema.Character{} = character, %{id: map_id} = _new_map) do
-    if Storage.Tables.InstanceFields.instanced?(map_id) do
-      Map.put(character, :map_id, map_id)
-    else
-      {:ok, character} = Context.Characters.update(character, %{map_id: map_id})
-      character
-    end
+    {:ok, character} = Context.Characters.update(character, %{map_id: map_id})
+    character
   end
 
   @doc """

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -60,7 +60,8 @@ defmodule Ms2ex.Managers.Field do
   """
   @spec enter(Schema.Character.t()) :: :ok | {:ok, pid()} | {:error, term()}
   def enter(%Schema.Character{} = character) do
-    pid = field_pid(character.map_id, character.channel_id)
+    instance_id = instance_id(character.map_id)
+    pid = field_pid(character.map_id, character.channel_id, instance_id)
 
     if pid && Process.alive?(pid) do
       call(pid, {:add_character, character})
@@ -68,8 +69,23 @@ defmodule Ms2ex.Managers.Field do
       GenServer.start(
         __MODULE__,
         character,
-        name: field_name(character.map_id, character.channel_id)
+        name: field_name(character.map_id, character.channel_id, instance_id)
       )
+    end
+  end
+
+  @doc """
+  The field instance id a character enters for the map: solo maps
+  (tutorials, quest instances) run one private field per entry, so a
+  fresh id is allocated per call; every other map — including
+  channel-scale ones — shares a single field per channel (id 0).
+  """
+  @spec instance_id(integer()) :: integer()
+  def instance_id(map_id) do
+    if Storage.Tables.InstanceFields.solo?(map_id) do
+      System.unique_integer([:positive])
+    else
+      0
     end
   end
 
@@ -169,14 +185,18 @@ defmodule Ms2ex.Managers.Field do
     PubSub.unsubscribe(Ms2ex.PubSub, to_string(topic))
   end
 
-  @doc "Generates a unique field process name from a map ID and channel ID."
-  @spec field_name(integer(), integer()) :: atom()
-  def field_name(map_id, channel_id) do
-    :"field:#{map_id}:channel:#{channel_id}"
+  @doc """
+  Generates a unique field process name from a map ID, channel ID and
+  instance ID. Instance 0 is the shared field of the map on the channel;
+  instanced maps (see `Storage.Tables.InstanceFields`) carry their own id.
+  """
+  @spec field_name(integer(), integer(), integer()) :: atom()
+  def field_name(map_id, channel_id, instance_id \\ 0) do
+    :"field:#{map_id}:channel:#{channel_id}:instance:#{instance_id}"
   end
 
-  defp field_pid(map_id, channel_id) do
-    Process.whereis(field_name(map_id, channel_id))
+  defp field_pid(map_id, channel_id, instance_id) do
+    Process.whereis(field_name(map_id, channel_id, instance_id))
   end
 
   # -- process plumbing ------------------------------------------------------

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -81,21 +81,19 @@ defmodule Ms2ex.Managers.Field do
     # character (change_field stamps it into change_map): a repeated field
     # enter for the same visit rejoins the same field instead of spawning
     # another one
-    instance =
-      character.field_instance ||
-        instance_id(character.map_id)
-
+    instance = character.field_instance || instance_id(character.map_id)
     character = Map.put(character, :field_instance, instance)
-    pid = field_pid(character.map_id, character.channel_id, instance)
+    opts = [name: field_name(character.map_id, character.channel_id, instance)]
 
-    if pid && Process.alive?(pid) do
-      call(pid, {:add_character, character})
-    else
-      GenServer.start(
-        __MODULE__,
-        character,
-        name: field_name(character.map_id, character.channel_id, instance)
-      )
+    case GenServer.start(__MODULE__, character, opts) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, pid}} ->
+        call(pid, {:add_character, character})
+
+      error ->
+        error
     end
   end
 
@@ -135,15 +133,13 @@ defmodule Ms2ex.Managers.Field do
   @spec change_field(Schema.Character.t(), integer(), map(), map()) :: :ok | {:error, term()}
   def change_field(character, map_id, position, rotation) do
     instance = instance_id(map_id)
+    change_map = %{id: map_id, position: position, rotation: rotation, instance: instance}
 
     with :ok <- leave_for_change(character) do
       character =
         character
         |> Context.Characters.maybe_discover_map(map_id)
-        |> Map.put(
-          :change_map,
-          %{id: map_id, position: position, rotation: rotation, instance: instance}
-        )
+        |> Map.put(:change_map, change_map)
 
       Managers.Character.call(character, {:update, character})
 
@@ -225,9 +221,6 @@ defmodule Ms2ex.Managers.Field do
     :"field:#{map_id}:channel:#{channel_id}:instance:#{instance_id}"
   end
 
-  defp field_pid(map_id, channel_id, instance_id) do
-    Process.whereis(field_name(map_id, channel_id, instance_id))
-  end
 
   # -- process plumbing ------------------------------------------------------
 

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -54,14 +54,39 @@ defmodule Ms2ex.Managers.Field do
   # -- lifecycle -------------------------------------------------------------
 
   @doc """
+  Binds the character to a field instance: a pending `change_map` instance
+  (fresh allocation from `change_field/2,4`) wins, an existing stamp is
+  kept while the character stays on the same field, anything else
+  allocates.
+  """
+  @spec assign_instance(Schema.Character.t()) :: Schema.Character.t()
+  def assign_instance(%Schema.Character{change_map: %{instance: instance}} = character),
+    do: Map.put(character, :field_instance, instance)
+
+  def assign_instance(%Schema.Character{field_instance: instance} = character)
+      when is_integer(instance),
+      do: character
+
+  def assign_instance(%Schema.Character{} = character),
+    do: Map.put(character, :field_instance, instance_id(character.map_id))
+
+  @doc """
   Adds a character to a field, creating the field process if it doesn't
   exist. Returns `{:ok, pid}` for a fresh field, `{:ok, field_pid}` when the
   character joined an existing one.
   """
   @spec enter(Schema.Character.t()) :: :ok | {:ok, pid()} | {:error, term()}
   def enter(%Schema.Character{} = character) do
-    instance_id = instance_id(character.map_id)
-    pid = field_pid(character.map_id, character.channel_id, instance_id)
+    # the instance is allocated once per transition and carried on the
+    # character (change_field stamps it into change_map): a repeated field
+    # enter for the same visit rejoins the same field instead of spawning
+    # another one
+    instance =
+      character.field_instance ||
+        instance_id(character.map_id)
+
+    character = Map.put(character, :field_instance, instance)
+    pid = field_pid(character.map_id, character.channel_id, instance)
 
     if pid && Process.alive?(pid) do
       call(pid, {:add_character, character})
@@ -69,7 +94,7 @@ defmodule Ms2ex.Managers.Field do
       GenServer.start(
         __MODULE__,
         character,
-        name: field_name(character.map_id, character.channel_id, instance_id)
+        name: field_name(character.map_id, character.channel_id, instance)
       )
     end
   end
@@ -109,11 +134,16 @@ defmodule Ms2ex.Managers.Field do
   @doc "Changes a character's field to a new map at a specific position."
   @spec change_field(Schema.Character.t(), integer(), map(), map()) :: :ok | {:error, term()}
   def change_field(character, map_id, position, rotation) do
+    instance = instance_id(map_id)
+
     with :ok <- leave_for_change(character) do
       character =
         character
         |> Context.Characters.maybe_discover_map(map_id)
-        |> Map.put(:change_map, %{id: map_id, position: position, rotation: rotation})
+        |> Map.put(
+          :change_map,
+          %{id: map_id, position: position, rotation: rotation, instance: instance}
+        )
 
       Managers.Character.call(character, {:update, character})
 
@@ -138,7 +168,7 @@ defmodule Ms2ex.Managers.Field do
   @doc "Broadcasts a packet to every character on a field."
   @spec broadcast(Schema.Character.t() | term(), binary()) :: :ok
   def broadcast(%Schema.Character{} = character, packet) do
-    topic = field_name(character.map_id, character.channel_id)
+    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
     broadcast(topic, packet)
   end
 
@@ -167,21 +197,21 @@ defmodule Ms2ex.Managers.Field do
   """
   @spec broadcast_from(Schema.Character.t(), binary(), pid()) :: :ok
   def broadcast_from(%Schema.Character{} = character, packet, from) do
-    topic = field_name(character.map_id, character.channel_id)
+    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
     PubSub.broadcast_from(Ms2ex.PubSub, from, to_string(topic), {:push, packet})
   end
 
   @doc "Subscribes the current process to a character's field events."
   @spec subscribe(Schema.Character.t()) :: :ok | {:error, term()}
   def subscribe(%Schema.Character{} = character) do
-    topic = field_name(character.map_id, character.channel_id)
+    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
     PubSub.subscribe(Ms2ex.PubSub, to_string(topic))
   end
 
   @doc "Unsubscribes the current process from a character's field events."
   @spec unsubscribe(Schema.Character.t()) :: :ok
   def unsubscribe(%Schema.Character{} = character) do
-    topic = field_name(character.map_id, character.channel_id)
+    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
     PubSub.unsubscribe(Ms2ex.PubSub, to_string(topic))
   end
 
@@ -541,7 +571,8 @@ defmodule Ms2ex.Managers.Field do
   def init(%{map_id: map_id, channel_id: channel_id} = character) do
     Logger.info("Start Field #{map_id} @ Channel #{channel_id}")
 
-    field_name = field_name(map_id, channel_id)
+    instance = character.field_instance || 0
+    field_name = field_name(map_id, channel_id, instance)
 
     {local_id_counter, portals} = __MODULE__.Portal.load(map_id, @local_id_counter)
     interactable = __MODULE__.InteractObject.load(map_id)
@@ -551,6 +582,7 @@ defmodule Ms2ex.Managers.Field do
         buffs: %{},
         banners: __MODULE__.Banner.load(map_id),
         channel_id: channel_id,
+        instance: instance,
         local_id_counter: local_id_counter,
         interactable: interactable,
         instruments: %{},

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -83,7 +83,7 @@ defmodule Ms2ex.Managers.Field do
     # another one
     instance = character.field_instance || instance_id(character.map_id)
     character = Map.put(character, :field_instance, instance)
-    opts = [name: field_name(character.map_id, character.channel_id, instance)]
+    opts = [name: field_name(character)]
 
     case GenServer.start(__MODULE__, character, opts) do
       {:ok, pid} ->
@@ -164,7 +164,7 @@ defmodule Ms2ex.Managers.Field do
   @doc "Broadcasts a packet to every character on a field."
   @spec broadcast(Schema.Character.t() | term(), binary()) :: :ok
   def broadcast(%Schema.Character{} = character, packet) do
-    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
+    topic = field_name(character)
     broadcast(topic, packet)
   end
 
@@ -193,22 +193,31 @@ defmodule Ms2ex.Managers.Field do
   """
   @spec broadcast_from(Schema.Character.t(), binary(), pid()) :: :ok
   def broadcast_from(%Schema.Character{} = character, packet, from) do
-    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
+    topic = field_name(character)
     PubSub.broadcast_from(Ms2ex.PubSub, from, to_string(topic), {:push, packet})
   end
 
   @doc "Subscribes the current process to a character's field events."
   @spec subscribe(Schema.Character.t()) :: :ok | {:error, term()}
   def subscribe(%Schema.Character{} = character) do
-    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
+    topic = field_name(character)
     PubSub.subscribe(Ms2ex.PubSub, to_string(topic))
   end
 
   @doc "Unsubscribes the current process from a character's field events."
   @spec unsubscribe(Schema.Character.t()) :: :ok
   def unsubscribe(%Schema.Character{} = character) do
-    topic = field_name(character.map_id, character.channel_id, character.field_instance || 0)
+    topic = field_name(character)
     PubSub.unsubscribe(Ms2ex.PubSub, to_string(topic))
+  end
+
+  @doc """
+  Field process name / PubSub topic for the field a character is on. A
+  missing instance id is the map's shared field (instance 0).
+  """
+  @spec field_name(Schema.Character.t()) :: atom()
+  def field_name(%Schema.Character{} = character) do
+    field_name(character.map_id, character.channel_id, character.field_instance)
   end
 
   @doc """
@@ -216,9 +225,9 @@ defmodule Ms2ex.Managers.Field do
   instance ID. Instance 0 is the shared field of the map on the channel;
   instanced maps (see `Storage.Tables.InstanceFields`) carry their own id.
   """
-  @spec field_name(integer(), integer(), integer()) :: atom()
-  def field_name(map_id, channel_id, instance_id \\ 0) do
-    :"field:#{map_id}:channel:#{channel_id}:instance:#{instance_id}"
+  @spec field_name(integer(), integer(), integer() | nil) :: atom()
+  def field_name(map_id, channel_id, instance_id) do
+    :"field:#{map_id}:channel:#{channel_id}:instance:#{instance_id || 0}"
   end
 
 

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -54,17 +54,33 @@ defmodule Ms2ex.Managers.Field do
   # -- lifecycle -------------------------------------------------------------
 
   @doc """
-  Persists the character's current map after a field change; the in-memory
-  map id follows the new map. Instanced maps persist like any other: the
-  reference saves the current stage on quit (only maps that push a
-  return-map reset it, which plain solo maps never do), so a relog lands
-  in a fresh instance of the same stage.
+  Persists the character's current map after a field change: maps that
+  declare an `enter_return_id` persist the return target instead (the
+  reference's logout reset, collapsed from its return-map stack), so a
+  relog inside a quest instance lands at its hub. The in-memory map id
+  still follows the actual map: the field process and quest conditions
+  are built from it.
   """
   @spec update_current_map(Schema.Character.t(), map()) :: Schema.Character.t()
   def update_current_map(%Schema.Character{} = character, %{id: map_id} = _new_map) do
-    {:ok, character} = Context.Characters.update(character, %{map_id: map_id})
-    character
+    {:ok, character} = Context.Characters.update(character, %{map_id: return_map_id(map_id)})
+    Map.put(character, :map_id, map_id)
   end
+
+  @doc """
+  The map a character who quit on `map_id` should return to: the map's
+  `enter_return_id` when it declares one, the map itself otherwise.
+  """
+  @spec return_map_id(integer()) :: integer()
+  def return_map_id(map_id) do
+    case Storage.Maps.get_meta(map_id) do
+      %{} = meta -> normalize_return(Map.get(meta, :enter_return_id), map_id)
+      _ -> map_id
+    end
+  end
+
+  defp normalize_return(id, _map_id) when is_integer(id) and id > 0, do: id
+  defp normalize_return(_, map_id), do: map_id
 
   @doc """
   Binds the character to a field instance: a pending `change_map` instance

--- a/lib/ms2ex/managers/field.ex
+++ b/lib/ms2ex/managers/field.ex
@@ -60,20 +60,6 @@ defmodule Ms2ex.Managers.Field do
   # -- lifecycle -------------------------------------------------------------
 
   @doc """
-  Persists the character's current map after a field change: maps that
-  declare an `enter_return_id` persist the return target instead (the
-  reference's logout reset, collapsed from its return-map stack), so a
-  relog inside a quest instance lands at its hub. The in-memory map id
-  still follows the actual map: the field process and quest conditions
-  are built from it.
-  """
-  @spec update_current_map(Schema.Character.t(), map()) :: Schema.Character.t()
-  def update_current_map(%Schema.Character{} = character, %{id: map_id} = _new_map) do
-    {:ok, character} = Context.Characters.update(character, %{map_id: return_map_id(map_id)})
-    Map.put(character, :map_id, map_id)
-  end
-
-  @doc """
   The map a character who quit on `map_id` should return to: the map's
   `enter_return_id` when it declares one, the map itself otherwise.
   """
@@ -121,9 +107,6 @@ defmodule Ms2ex.Managers.Field do
     opts = [name: field_name(character)]
 
     case GenServer.start(__MODULE__, character, opts) do
-      {:ok, pid} ->
-        {:ok, pid}
-
       {:error, {:already_started, pid}} ->
         call(pid, {:add_character, character})
 

--- a/lib/ms2ex/managers/field/character.ex
+++ b/lib/ms2ex/managers/field/character.ex
@@ -100,7 +100,7 @@ defmodule Ms2ex.Managers.Field.Character do
     push(character, Packets.Wedding.update_hall())
     push(character, Packets.ResponseCube.design_rank_reward(character.account_id))
     push(character, Packets.ResponseCube.update_profile(character))
-    push(character, Packets.ResponseCube.return_map(character.map_id))
+    push(character, Packets.ResponseCube.return_map(Managers.Field.return_map_id(character.map_id)))
     push(character, Packets.Lapenshard.load())
 
     tick = Ms2ex.sync_ticks()

--- a/lib/ms2ex/managers/field/character.ex
+++ b/lib/ms2ex/managers/field/character.ex
@@ -22,8 +22,7 @@ defmodule Ms2ex.Managers.Field.Character do
     # stays stable across field transitions; only the field changes here
     character = %{character | map_id: state.map_id}
 
-    character = Map.put(character, :field_pid, self())
-    character = Map.put(character, :field_instance, state.instance)
+    character = %{character | field_pid: self(), field_instance: state.instance}
     Managers.Character.call(character, {:update, character})
 
     sessions = Map.put(state.sessions, character.id, character.sender_session_pid)

--- a/lib/ms2ex/managers/field/character.ex
+++ b/lib/ms2ex/managers/field/character.ex
@@ -23,6 +23,7 @@ defmodule Ms2ex.Managers.Field.Character do
     character = %{character | map_id: state.map_id}
 
     character = Map.put(character, :field_pid, self())
+    character = Map.put(character, :field_instance, state.instance)
     Managers.Character.call(character, {:update, character})
 
     sessions = Map.put(state.sessions, character.id, character.sender_session_pid)

--- a/lib/ms2ex/managers/field/trigger/actions.ex
+++ b/lib/ms2ex/managers/field/trigger/actions.ex
@@ -997,11 +997,21 @@ defmodule Ms2ex.Managers.Field.Trigger.Actions do
 
   defp move_player(state, character, map_id, portal) do
     state = Managers.Field.Character.remove_character(character, state)
+    # the solo field the script just vacated has no reason to keep running
+    send(self(), :maybe_stop)
 
     character =
       character
       |> Context.Characters.maybe_discover_map(map_id)
-      |> Map.put(:change_map, %{id: map_id, position: portal.position, rotation: portal.rotation})
+      |> Map.put(
+        :change_map,
+        %{
+          id: map_id,
+          position: portal.position,
+          rotation: portal.rotation,
+          instance: Managers.Field.instance_id(map_id)
+        }
+      )
 
     Managers.Character.call(character, {:update, character})
 

--- a/lib/ms2ex/managers/guild_server.ex
+++ b/lib/ms2ex/managers/guild_server.ex
@@ -142,10 +142,7 @@ defmodule Ms2ex.Managers.GuildServer do
         {:reply, :error, state}
 
       member ->
-        updated_member =
-          member
-          |> Map.put(:map_id, map_id)
-          |> Map.put(:field_instance, field_instance || 0)
+        updated_member = Map.merge(member, %{map_id: map_id, field_instance: field_instance})
 
         members = Map.put(state.members, character_id, updated_member)
         state = %{state | members: members}
@@ -822,7 +819,7 @@ defmodule Ms2ex.Managers.GuildServer do
       job: char.job,
       map_id: char.map_id,
       channel: char.channel_id || 1,
-      field_instance: char.field_instance || 0,
+      field_instance: char.field_instance,
       profile_url: char.profile_url || "",
       gear_score: char.gear_score || 0,
       trophies: char.trophies || [0, 0, 0],
@@ -840,7 +837,7 @@ defmodule Ms2ex.Managers.GuildServer do
       job: char.job || :beginner,
       map_id: char.map_id || 1,
       channel: 1,
-      field_instance: 0,
+      field_instance: nil,
       profile_url: char.profile_url || "",
       gear_score: char.gear_score || 0,
       trophies: char.trophies || [0, 0, 0],

--- a/lib/ms2ex/managers/guild_server.ex
+++ b/lib/ms2ex/managers/guild_server.ex
@@ -136,13 +136,16 @@ defmodule Ms2ex.Managers.GuildServer do
     end
   end
 
-  def handle_call({:update_member_map, character_id, map_id}, _from, state) do
+  def handle_call({:update_member_map, character_id, map_id, field_instance}, _from, state) do
     case Map.get(state.members, character_id) do
       nil ->
         {:reply, :error, state}
 
       member ->
-        updated_member = Map.put(member, :map_id, map_id)
+        updated_member =
+          member
+          |> Map.put(:map_id, map_id)
+          |> Map.put(:field_instance, field_instance || 0)
         members = Map.put(state.members, character_id, updated_member)
         state = %{state | members: members}
 
@@ -525,7 +528,8 @@ defmodule Ms2ex.Managers.GuildServer do
             Managers.GuildServer.unsubscribe(state.id)
           end)
 
-          topic = Managers.Field.field_name(target.map_id, target.channel)
+          topic =
+            Managers.Field.field_name(target.map_id, target.channel, Map.get(target, :field_instance, 0))
           Managers.Field.broadcast(topic, Packets.Guild.remove_tag(target.name))
 
           SenderSession.push(
@@ -812,6 +816,7 @@ defmodule Ms2ex.Managers.GuildServer do
       job: char.job,
       map_id: char.map_id,
       channel: char.channel_id || 1,
+      field_instance: char.field_instance || 0,
       profile_url: char.profile_url || "",
       gear_score: char.gear_score || 0,
       trophies: char.trophies || [0, 0, 0],
@@ -829,6 +834,7 @@ defmodule Ms2ex.Managers.GuildServer do
       job: char.job || :beginner,
       map_id: char.map_id || 1,
       channel: 1,
+      field_instance: 0,
       profile_url: char.profile_url || "",
       gear_score: char.gear_score || 0,
       trophies: char.trophies || [0, 0, 0],

--- a/lib/ms2ex/managers/guild_server.ex
+++ b/lib/ms2ex/managers/guild_server.ex
@@ -146,6 +146,7 @@ defmodule Ms2ex.Managers.GuildServer do
           member
           |> Map.put(:map_id, map_id)
           |> Map.put(:field_instance, field_instance || 0)
+
         members = Map.put(state.members, character_id, updated_member)
         state = %{state | members: members}
 
@@ -529,7 +530,12 @@ defmodule Ms2ex.Managers.GuildServer do
           end)
 
           topic =
-            Managers.Field.field_name(target.map_id, target.channel, Map.get(target, :field_instance, 0))
+            Managers.Field.field_name(
+              target.map_id,
+              target.channel,
+              Map.get(target, :field_instance, 0)
+            )
+
           Managers.Field.broadcast(topic, Packets.Guild.remove_tag(target.name))
 
           SenderSession.push(

--- a/lib/ms2ex/managers/guild_server.ex
+++ b/lib/ms2ex/managers/guild_server.ex
@@ -526,12 +526,7 @@ defmodule Ms2ex.Managers.GuildServer do
             Managers.GuildServer.unsubscribe(state.id)
           end)
 
-          topic =
-            Managers.Field.field_name(
-              target.map_id,
-              target.channel,
-              Map.get(target, :field_instance, 0)
-            )
+          topic = Managers.Field.field_name(target.map_id, target.channel, target.field_instance)
 
           Managers.Field.broadcast(topic, Packets.Guild.remove_tag(target.name))
 

--- a/lib/ms2ex/schema/character.ex
+++ b/lib/ms2ex/schema/character.ex
@@ -115,6 +115,9 @@ defmodule Ms2ex.Schema.Character do
     field :death_tick, :integer, default: 0
     field :instant_revive_count, :integer, default: 0
     field :field_pid, EctoTypes.Term, virtual: true
+    # the field instance the session is bound to; allocated once per
+    # transition and never persisted (see Managers.Field.assign_instance/1)
+    field :field_instance, :integer, virtual: true
     field :gender, Ms2ex.Enums.Gender, default: :male
     field :gear_score, :integer, virtual: true, default: 0
     field :guild_id, :integer, virtual: true, default: 0

--- a/lib/ms2ex/storage/table/instance_fields.ex
+++ b/lib/ms2ex/storage/table/instance_fields.ex
@@ -1,0 +1,36 @@
+defmodule Ms2ex.Storage.Tables.InstanceFields do
+  @moduledoc """
+  Instance-field table: maps that are instanced rather than shared.
+  `solo` maps (tutorials, quest instances) allocate a private field per
+  entry; `channel_scale` maps share one field per channel. Maps absent
+  from the table are ordinary shared fields.
+  """
+
+  alias Ms2ex.Storage
+
+  @table_name "server.instancefield.xml"
+
+  @doc "Instance doc for a map (`:type`, `:instance_id`, `:pool_count`,
+  `:max_count`, `:save_field`, `:npc_stat_factor_id`), or nil when the
+  map is not instanced."
+  @spec get(integer()) :: map() | nil
+  def get(map_id) do
+    case Storage.get(:table, @table_name) do
+      %{} = fields -> Map.get(fields, map_id)
+      _ -> nil
+    end
+  end
+
+  @doc "Whether the map is instanced at all (any instance type)."
+  @spec instanced?(integer()) :: boolean()
+  def instanced?(map_id), do: get(map_id) != nil
+
+  @doc "Whether the map allocates a private field instance per entry."
+  @spec solo?(integer()) :: boolean()
+  def solo?(map_id) do
+    case get(map_id) do
+      %{type: :solo} -> true
+      _ -> false
+    end
+  end
+end

--- a/test/ms2ex/field_dispose_test.exs
+++ b/test/ms2ex/field_dispose_test.exs
@@ -1,0 +1,49 @@
+defmodule Ms2ex.FieldDisposeTest do
+  use ExUnit.Case, async: true
+
+  alias Ms2ex.Managers.Field
+
+  defp shared_state do
+    %{sessions: %{}, instance: 0, dispose_timer: nil, map_id: 2_000_000, channel_id: 1}
+  end
+
+  defp instanced_state do
+    %{sessions: %{}, instance: 3, dispose_timer: nil, map_id: 52_000_101, channel_id: 1}
+  end
+
+  test "an empty shared field arms the dispose timer" do
+    assert {:noreply, state} = Field.handle_info(:maybe_stop, shared_state())
+    assert is_reference(state.dispose_timer)
+  end
+
+  test "the dispose timer fires only while the field is still empty" do
+    state = %{shared_state() | dispose_timer: Process.send_after(self(), :noop, 50_000)}
+
+    assert {:stop, :normal, _} = Field.handle_info(:dispose_if_empty, state)
+
+    # a player joined before the timer fired: keep the field, drop the timer
+    state = %{shared_state() | dispose_timer: Process.send_after(self(), :noop, 50_000)}
+    state = %{state | sessions: %{1 => self()}}
+
+    assert {:noreply, %{dispose_timer: nil}} = Field.handle_info(:dispose_if_empty, state)
+  end
+
+  test "re-arming replaces the pending timer" do
+    state = Field.handle_info(:maybe_stop, shared_state()) |> elem(1)
+    first_timer = state.dispose_timer
+
+    assert {:noreply, state} = Field.handle_info(:maybe_stop, state)
+    assert is_reference(state.dispose_timer)
+    assert state.dispose_timer != first_timer
+  end
+
+  test "an empty instanced field stops immediately" do
+    assert {:stop, :normal, _} = Field.handle_info(:maybe_stop, instanced_state())
+  end
+
+  test "a leave while other players remain does not arm anything" do
+    state = %{shared_state() | sessions: %{1 => self(), 2 => self()}}
+
+    assert {:noreply, %{dispose_timer: nil}} = Field.handle_info(:maybe_stop, state)
+  end
+end

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -1,5 +1,6 @@
 defmodule Ms2ex.InstanceFieldsTest do
   use Ms2ex.DataCase, async: true
+  use Mimic
 
   alias Ms2ex.Managers
   alias Ms2ex.Schema
@@ -77,8 +78,13 @@ defmodule Ms2ex.InstanceFieldsTest do
              Managers.Field.assign_instance(%Schema.Character{map_id: @channel_scale_map})
   end
 
-  test "a field change to an instanced map moves the in-memory map, not the saved one" do
+  test "a field change persists and follows the new map (instanced or not)" do
     character = %Schema.Character{map_id: @shared_map, change_map: nil}
+
+    Mimic.expect(Ms2ex.Context.Characters, :update, fn char, attrs ->
+      assert attrs == %{map_id: @tutorial_map}
+      {:ok, %{char | map_id: @tutorial_map}}
+    end)
 
     new_map = %{id: @tutorial_map, position: %{x: 0, y: 0, z: 0}, rotation: nil, instance: 3}
 

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -1,0 +1,57 @@
+defmodule Ms2ex.InstanceFieldsTest do
+  use Ms2ex.DataCase, async: true
+
+  alias Ms2ex.Managers
+  alias Ms2ex.Storage.Tables.InstanceFields
+
+  @tutorial_map 52_000_001
+  @channel_scale_map 52_000_058
+  @shared_map 2_000_000
+
+  @table_doc %{
+    @tutorial_map => %{type: :solo, instance_id: 1_000_011, pool_count: 0, max_count: 0},
+    @channel_scale_map => %{
+      type: :channel_scale,
+      instance_id: 1_000_068,
+      pool_count: 0,
+      max_count: 20
+    }
+  }
+
+  setup do
+    stub_metadata(%{"table:server.instancefield.xml" => @table_doc})
+    :ok
+  end
+
+  test "returns the instance doc of a listed map" do
+    assert %{type: :solo, instance_id: 1_000_011} = InstanceFields.get(@tutorial_map)
+  end
+
+  test "unlisted maps are not instanced" do
+    assert InstanceFields.get(@shared_map) == nil
+    refute InstanceFields.instanced?(@shared_map)
+  end
+
+  test "solo? holds only for solo maps" do
+    assert InstanceFields.solo?(@tutorial_map)
+    refute InstanceFields.solo?(@channel_scale_map)
+    refute InstanceFields.solo?(@shared_map)
+  end
+
+  test "field names separate instances of the same map and channel" do
+    assert Managers.Field.field_name(@tutorial_map, 1, 0) ==
+             :"field:52000001:channel:1:instance:0"
+
+    assert Managers.Field.field_name(@tutorial_map, 1, 7) !=
+             Managers.Field.field_name(@tutorial_map, 1, 8)
+  end
+
+  test "solo maps allocate a fresh instance id per entry, others share" do
+    assert first = Managers.Field.instance_id(@tutorial_map)
+    assert second = Managers.Field.instance_id(@tutorial_map)
+    assert first != second
+
+    assert Managers.Field.instance_id(@channel_scale_map) == 0
+    assert Managers.Field.instance_id(@shared_map) == 0
+  end
+end

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -39,6 +39,15 @@ defmodule Ms2ex.InstanceFieldsTest do
     refute InstanceFields.solo?(@shared_map)
   end
 
+  test "field names normalize a missing instance to the shared field" do
+    assert Managers.Field.field_name(@shared_map, 1, nil) ==
+             :"field:2000000:channel:1:instance:0"
+
+    character = %Schema.Character{map_id: @shared_map, channel_id: 1}
+
+    assert Managers.Field.field_name(character) == :"field:2000000:channel:1:instance:0"
+  end
+
   test "field names separate instances of the same map and channel" do
     assert Managers.Field.field_name(@tutorial_map, 1, 0) ==
              :"field:52000001:channel:1:instance:0"

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -77,6 +77,14 @@ defmodule Ms2ex.InstanceFieldsTest do
              Managers.Field.assign_instance(%Schema.Character{map_id: @channel_scale_map})
   end
 
+  test "a field change to an instanced map moves the in-memory map, not the saved one" do
+    character = %Schema.Character{map_id: @shared_map, change_map: nil}
+
+    new_map = %{id: @tutorial_map, position: %{x: 0, y: 0, z: 0}, rotation: nil, instance: 3}
+
+    assert %{map_id: @tutorial_map} = Managers.Field.update_current_map(character, new_map)
+  end
+
   test "solo maps allocate a fresh instance id per entry, others share" do
     assert first = Managers.Field.instance_id(@tutorial_map)
     assert second = Managers.Field.instance_id(@tutorial_map)

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -2,6 +2,7 @@ defmodule Ms2ex.InstanceFieldsTest do
   use Ms2ex.DataCase, async: true
 
   alias Ms2ex.Managers
+  alias Ms2ex.Schema
   alias Ms2ex.Storage.Tables.InstanceFields
 
   @tutorial_map 52_000_001
@@ -44,6 +45,27 @@ defmodule Ms2ex.InstanceFieldsTest do
 
     assert Managers.Field.field_name(@tutorial_map, 1, 7) !=
              Managers.Field.field_name(@tutorial_map, 1, 8)
+  end
+
+  test "assign_instance keeps the pending change_map instance" do
+    character = %Schema.Character{map_id: @tutorial_map, change_map: %{instance: 9}}
+
+    assert %{field_instance: 9} = Managers.Field.assign_instance(character)
+  end
+
+  test "assign_instance keeps the current stamp while on the same field" do
+    character = %Schema.Character{map_id: @tutorial_map, field_instance: 5}
+
+    assert %{field_instance: 5} = Managers.Field.assign_instance(character)
+  end
+
+  test "assign_instance allocates for solo maps and binds shared maps to 0" do
+    assert first = Managers.Field.assign_instance(%Schema.Character{map_id: @tutorial_map})
+    assert second = Managers.Field.assign_instance(%Schema.Character{map_id: @tutorial_map})
+    assert first.field_instance != second.field_instance
+
+    assert %{field_instance: 0} =
+             Managers.Field.assign_instance(%Schema.Character{map_id: @channel_scale_map})
   end
 
   test "solo maps allocate a fresh instance id per entry, others share" do

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -83,35 +83,9 @@ defmodule Ms2ex.InstanceFieldsTest do
              Managers.Field.assign_instance(%Schema.Character{map_id: @channel_scale_map})
   end
 
-  test "a map with an enter_return_id persists the return target" do
-    Mimic.expect(Ms2ex.Context.Characters, :update, fn _char, attrs ->
-      assert attrs == %{map_id: 2_000_301}
-      {:ok, %Schema.Character{map_id: 2_000_301}}
-    end)
-
-    new_map = %{id: @quest_instance, position: %{x: 0, y: 0, z: 0}, rotation: nil, instance: 3}
-
-    # in-memory map id follows the actual map; the saved one is the hub
-    assert %{map_id: @quest_instance} =
-             Managers.Field.update_current_map(%Schema.Character{map_id: @shared_map}, new_map)
-  end
-
   test "return_map_id falls back to the map itself" do
     assert Managers.Field.return_map_id(@tutorial_map) == @tutorial_map
     assert Managers.Field.return_map_id(@quest_instance) == 2_000_301
-  end
-
-  test "a field change persists and follows the new map (instanced or not)" do
-    character = %Schema.Character{map_id: @shared_map, change_map: nil}
-
-    Mimic.expect(Ms2ex.Context.Characters, :update, fn char, attrs ->
-      assert attrs == %{map_id: @tutorial_map}
-      {:ok, %{char | map_id: @tutorial_map}}
-    end)
-
-    new_map = %{id: @tutorial_map, position: %{x: 0, y: 0, z: 0}, rotation: nil, instance: 3}
-
-    assert %{map_id: @tutorial_map} = Managers.Field.update_current_map(character, new_map)
   end
 
   test "solo maps allocate a fresh instance id per entry, others share" do

--- a/test/ms2ex/instance_fields_test.exs
+++ b/test/ms2ex/instance_fields_test.exs
@@ -9,6 +9,7 @@ defmodule Ms2ex.InstanceFieldsTest do
   @tutorial_map 52_000_001
   @channel_scale_map 52_000_058
   @shared_map 2_000_000
+  @quest_instance 63_000_015
 
   @table_doc %{
     @tutorial_map => %{type: :solo, instance_id: 1_000_011, pool_count: 0, max_count: 0},
@@ -21,7 +22,11 @@ defmodule Ms2ex.InstanceFieldsTest do
   }
 
   setup do
-    stub_metadata(%{"table:server.instancefield.xml" => @table_doc})
+    stub_metadata(%{
+      "table:server.instancefield.xml" => @table_doc,
+      "map:63000015" => %{enter_return_id: 2_000_301}
+    })
+
     :ok
   end
 
@@ -76,6 +81,24 @@ defmodule Ms2ex.InstanceFieldsTest do
 
     assert %{field_instance: 0} =
              Managers.Field.assign_instance(%Schema.Character{map_id: @channel_scale_map})
+  end
+
+  test "a map with an enter_return_id persists the return target" do
+    Mimic.expect(Ms2ex.Context.Characters, :update, fn _char, attrs ->
+      assert attrs == %{map_id: 2_000_301}
+      {:ok, %Schema.Character{map_id: 2_000_301}}
+    end)
+
+    new_map = %{id: @quest_instance, position: %{x: 0, y: 0, z: 0}, rotation: nil, instance: 3}
+
+    # in-memory map id follows the actual map; the saved one is the hub
+    assert %{map_id: @quest_instance} =
+             Managers.Field.update_current_map(%Schema.Character{map_id: @shared_map}, new_map)
+  end
+
+  test "return_map_id falls back to the map itself" do
+    assert Managers.Field.return_map_id(@tutorial_map) == @tutorial_map
+    assert Managers.Field.return_map_id(@quest_instance) == 2_000_301
   end
 
   test "a field change persists and follows the new map (instanced or not)" do


### PR DESCRIPTION
## Summary

The reference keys fields by `(MapId, RoomId)` and drives instancing
from the instance-field table: maps flagged `solo` create a fresh field
on **every entry**, while unlisted (and `channelScale`) maps share one
field per channel. All tutorial maps (`51000xxx`, `52000xxx`) are
`solo` — which is why players entering the same tutorial collided and
broke each other's progression.

ms2ex now does the same:

- **Ingest**: `server.instancefield.xml` is projected into the `table`
  set (per-map `{type, instance_id, pool_count, max_count, save_field,
  npc_stat_factor_id}`), plus a `--probe-instance-field` dump of the raw
  table (596 entries: 428 solo, 47 channelScale, ...).
- **`Storage.Tables.InstanceFields`**: `get/1`, `instanced?/1`, `solo?/1`.
- **`Managers.Field.field_name/3`** carries the instance id;
  `Managers.Field.instance_id/1` allocates a fresh unique id per entry
  for `solo` maps, 0 (shared per channel) otherwise.
- **Relog parity**: instanced maps are never persisted as the character's
  current map (the handler skips the `map_id` update), so a relog returns
  the player to where the instance was entered from. In-memory the
  character still carries the instance map, so quest conditions and guild
  map updates keep crediting inside it.

## Docs

- New `docs/features/instanced-maps.md` (behavior, parity, open gaps:
  party follow into a leader's instance, dungeon/guild/wedding types,
  room pools, `max_count` caps, `save_field`)
- `docs/features/field-manager.md` naming section updated; ROADMAP +
  CHANGELOG entries

## Verification

- `mix compile`: 0 project warnings
- `mix test`: 370/370 (5 new tests: table accessors, field-name
  separation, per-entry allocation vs shared)
- Ingest re-run: table set went 28 → 29 docs; probe output verified
  against the raw XML

Ingest-side commit: sgessa/ms2ex-file-ingest `65867aa` (pushed to its master).